### PR TITLE
added a 'do I own this page' check when remixing a page

### DIFF
--- a/app.js
+++ b/app.js
@@ -171,7 +171,7 @@ app.get("/remix/:id", function(req, res) {
 app.post('/publish',
          middleware.checkForAuth,
          middleware.checkForPublishData,
-         middleware.checkForOriginalPage,
+         middleware.checkForOriginalPage(databaseAPI),
          bleach.bleachData(env.get("BLEACH_ENDPOINT")),
          middleware.saveData(databaseAPI, env.get('HOSTNAME')),
          middleware.rewritePublishId(databaseAPI),

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -44,14 +44,28 @@ module.exports = function middlewareCtor(env) {
      * page is a remix of. If there is no 'original', then
      * this will be an empty string.
      */
-    checkForOriginalPage: function(req, res, next) {
-      if(!req.body['original-url']) {
-        req.body['original-url'] = "";
-      } else {
-        var idPos = req.body['original-url'].lastIndexOf('/') + 1;
-        req.body['original-url'] = req.body['original-url'].substring(idPos);
-      }
-      next();
+    checkForOriginalPage: function(db) {
+      return function(req, res, next) {
+        if(!req.body['original-url']) {
+          req.body['original-url'] = "";
+          next();
+        } else {
+          var idPos = req.body['original-url'].lastIndexOf('/') + 1;
+          var originalId = req.body['original-url'].substring(idPos);
+
+          // Verify that the currently logged in user owns
+          // this page, otherwise they might try to update
+          // a non-existent page when they hit "publish".
+          db.find(originalId, function(err, result) {
+            if(err) {
+              return next(err);
+            }
+            var owner = (result.userid === req.session.email);
+            req.body['original-url'] = (owner? originalId : '');
+            next();
+          });
+        }
+      };
     },
 
     /**


### PR DESCRIPTION
this prevents the following scenario:

[A] publishes a page
[B] loads up the page /edit link
[B] hits publish
server sees this is a remix, and tries to update the page for B

because the page only exists for A, updating for B crashes thimble. No longer!
