### PR TITLE
Fixed Readme file to send point 2 to a new line. fixes bug [889557]

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Setup
 
 In order to run Thimble, the following things are required:
 
-1) you will need to have node installed
-
+1) you will need to have node installed.<br>
 2) you'll need to fork and then clone the repo recursively:
 
 ```


### PR DESCRIPTION
Previously

```
1) you will need to have node installed 2) you'll need to fork and then clone the repo recursively:
```

Corrected to

```
1) you will need to have node installed

2) you'll need to fork and then clone the repo recursively:
```
