### PR TITLE
[nobug - github #180] Editor and Preview indicator buttons position fix.

### DIFF
--- a/public/stylesheets/friendlycode-overrides.less
+++ b/public/stylesheets/friendlycode-overrides.less
@@ -22,6 +22,10 @@
   text-align: left!important;
 }
 
-.pane-indicator {
-  top: 38px!important;
+.editor-nav-item .pane-indicator{
+  top: 38px !important;
+}
+
+.preview-nav-item .pane-indicator{
+    top: 28px !important;
 }


### PR DESCRIPTION
.pane-indicator is used both in editor and preview parts, should specific it.
