### PR TITLE
Bug 898384 - update makeapi-client to v0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "helmet": "0.0.11",
     "htmlsanitizer": "0.0.2",
     "knox": "0.8.3",
-    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.4",
+    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.5",
     "less-middleware": "0.1.12",
     "newrelic": "0.9.20",
     "node-statsd": "0.0.7",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=898384
