### PR TITLE
forcing local links to stay local, despite base target=_blank

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -5,7 +5,7 @@
 export NODE_ENV="development"
 
 # JS enabled?
-export JAVASCRIPT_ENABLED=false
+export JAVASCRIPT_ENABLED=true
 
 # default thimble port is 3500
 export PORT=3500

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -300,8 +300,30 @@ module.exports = function middlewareConstructor(env) {
             // prevent index robots from following outbound links
             noFollow = '<meta name="robots" content="nofollow">\n';
 
-            // ensure iframe links open in their own tab/window
-            baseTag = '<base target="_blank">\n',
+            // Ensure that external links target _blank (unless the user
+            // already specified a target, in which case we do nothing)
+            var fixExternalLinks = function fixExternalLinks() {
+              function pointToBlank(a) {
+                var href = a.getAttribute("href");
+                if (href && href.indexOf("://") > -1) {
+                  // this is an external link.
+                  if(!a.getAttribute("target")) {
+                    a.setAttribute("target", "_blank");
+                  }
+                }
+              }
+              function fixLinks() {
+                document.removeEventListener("DOMContentLoaded", fixLinks);
+                var anchors = document.querySelectorAll("a");
+                var asArray = Array.prototype.slice.call(anchors);
+                asArray.forEach(function(a) {
+                  pointToBlank(a);
+                });
+              }
+              document.addEventListener("DOMContentLoaded", fixLinks);
+            };
+
+            var linkCorrection = "<script>(" + fixExternalLinks.toString() + "())</script>\n";
 
             // OpenGraph information
             metaTagsBlock = metaTagTemplate.render({
@@ -325,7 +347,7 @@ module.exports = function middlewareConstructor(env) {
         embedShell = embedShell.replace("</head", metaTagsBlock + googleAnalytics + "</head");
         req.remixUrl = remixUrl;
         req.body.embedShell = embedShell;
-        req.body.finalizedHTML = htmlData.replace("</head", baseTag + "</head");
+        req.body.finalizedHTML = htmlData.replace("</head", linkCorrection + "</head");
         next();
       };
     },


### PR DESCRIPTION
also has an essential env.dist fix, because otherwise this will crash and burn the moment you try to publish (remember to set JS allowed in your own .env, too. Bleach is no longer uesd for thimble)
