### PR TITLE
fixed conditional check

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ var appName = "thimble",
     app = express(),
     env = new habitat(),
     node_env = env.get('NODE_ENV'),
-    emulate_s3 = !env.get('S3_KEY') || env.get('S3_EMULATION'),
+    emulate_s3 = env.get('S3_EMULATION') || !env.get('S3_KEY'),
     WWW_ROOT = path.resolve(__dirname, 'public'),
     /**
       We're using two databases here: the first is our normal database, the second is

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -2,8 +2,8 @@ module.exports = function middlewareConstructor(env) {
 
   var metrics = require('./metrics')(env),
       utils = require("./utils"),
-      devmode = env.get("NODE_ENV") === "development",
-      knox = devmode ? require("noxmox").mox : require("knox");
+      emulate_s3 = env.get('S3_EMULATION') || !env.get('S3_KEY'),
+      knox = emulate_s3 ? require("noxmox").mox : require("knox");
 
   return {
     /**


### PR DESCRIPTION
env.dist will contain `S3_EMULATION=false`, so that the check by default will rely only on the s3_key. However, if there IS an s3_key, the S3_EMULATION flag can override s3 publication.
