### PR TITLE
Bug 923232 - Update node-newrelic to v0.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "knox": "0.8.5",
     "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.6",
     "less-middleware": "0.1.12",
-    "newrelic": "0.9.20",
+    "newrelic": "0.11.4",
     "moment": "2.2.1",
     "mox-server": "https://github.com/Pomax/mox-server/archive/master.tar.gz",
     "node-statsd": "0.0.7",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=923232
