### PR TITLE
bug#911172 - Changed nav-options from blue to gray

### DIFF
--- a/public/friendlycode/css/editor.less
+++ b/public/friendlycode/css/editor.less
@@ -259,7 +259,7 @@
   font-weight: bold;
   font-size: 16px;
   opacity: 1.0;
-  color: rgb(127,127,127);
+  color: #7F7F7F;
 }
 
 .editor-nav-item .icon,


### PR DESCRIPTION
A very simple and quick fix for the Editor and Preview text confusing people that they are links.

<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=911172">Link to the bugzilla</a>

![image](https://f.cloud.github.com/assets/1514285/1277716/b5f5b5e2-2eda-11e3-92b6-d9099e9e5d95.png)
