### PR TITLE
fixes the problem of the operations menu sitting under the new-user panel

### DIFF
--- a/public/stylesheets/buttons.less
+++ b/public/stylesheets/buttons.less
@@ -150,7 +150,7 @@
 
 // Menu group
 .butter-btn-menu-container {
-  z-index: 10;
+  z-index: 20;
   display: inline-block;
   position: relative;
   line-height: @_btnTotalHeight - 2; //borders


### PR DESCRIPTION
Fixes the problem highlighted in https://bug923777.bugzilla.mozilla.org/attachment.cgi?id=813842

new user panel has z-index 10, operations menu also has z-index 10. Changed it to 20.
