### PR TITLE
csrf-token rename

### DIFF
--- a/public/friendlycode/js/fc/ui/details-form.js
+++ b/public/friendlycode/js/fc/ui/details-form.js
@@ -24,7 +24,7 @@ define(['template!details-form'], function (detailsFormHTML) {
         $error = $(".title-error.error-message"),
         $button = $(".confirmation-button.yes-button"),
         title = this.value.toLowerCase(),
-        csrf_token = $("meta[name='X-CSRF-Token']").attr("content");
+        csrf_token = $("meta[name='csrf-token']").attr("content");
 
     $.ajax({
       type: "POST",
@@ -36,7 +36,7 @@ define(['template!details-form'], function (detailsFormHTML) {
       },
       dataType: 'json',
       beforeSend: function(request) {
-        request.setRequestHeader('X-CSRF-Token', csrf_token);
+        request.setRequestHeader('X-CSRF-Token', csrf_token); // express.js uses a non-standard name for csrf-token
       },
       error: function(req) {
         console.log("error while validating the title of your page")

--- a/views/friendlycode.html
+++ b/views/friendlycode.html
@@ -11,7 +11,7 @@
     define("hackpub", ["jquery"], function($) {
 
       // set up CSRF handling
-      var csrf_token = $("meta[name='X-CSRF-Token']").attr("content");
+      var csrf_token = $("meta[name='csrf-token']").attr("content");
 
       return function Hackpub(options) {
         return {
@@ -41,7 +41,7 @@
               },
               dataType: 'json',
               beforeSend: function(request) {
-                request.setRequestHeader('X-CSRF-Token', csrf_token);
+                request.setRequestHeader('X-CSRF-Token', csrf_token); // express.js uses a non-standard name for csrf-token
               },
               error: function(req) {
                 cb(req);

--- a/views/layout.html
+++ b/views/layout.html
@@ -6,7 +6,7 @@
     <meta name="persona-email" content="{{email}}">
     <meta name="thimble-operation" content="{{pageOperation}}">
     <meta name="thimble-project-origin" content="{{origin}}">
-    <meta name="X-CSRF-Token" content="{{csrf}}">
+    <meta name="csrf-token" content="{{csrf}}">
     <base target="_blank">
     <title>{{ gettext("Mozilla Thimble") }}</title>
     <link rel="stylesheet" href="{{userbar}}/css/nav.css" />


### PR DESCRIPTION
switch from "X-CSRF-Token" as meta name to the validation-passing "csrf-token"

https://bugzilla.mozilla.org/show_bug.cgi?id=930166
