### PR TITLE
tightened up the attribute parsing rules

### DIFF
--- a/public/friendlycode/vendor/slowparse/slowparse.js
+++ b/public/friendlycode/vendor/slowparse/slowparse.js
@@ -37,6 +37,17 @@ var Slowparse = (function() {
     amp: "&"
   };
 
+  // HTML attribute parsing rules are based on
+  // http://www.w3.org/TR/2011/WD-html5-20110525/elements.html#attr-data
+  // -> ref http://www.w3.org/TR/2011/WD-html5-20110525/infrastructure.html#xml-compatible
+  //    -> ref http://www.w3.org/TR/REC-xml/#NT-NameChar
+  // note: this lacks the final \\u10000-\\uEFFFF in the startchar set, because JavaScript
+  //       cannot cope with unciode characters with points over 0xFFFF.
+  var attributeNameStartChar = "A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
+  var nameStartChar = new RegExp("[" + attributeNameStartChar + "]");
+  var attributeNameChar = attributeNameStartChar + "0-9\\-\\.\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
+  var nameChar = new RegExp("[" + attributeNameChar + "]");
+
   //Define a property checker for https page
   var checkMixedContent = (window.location.protocol === "https:");
 
@@ -1234,10 +1245,8 @@ var Slowparse = (function() {
     // its tag name, looking for `attribute="value"` data until a
     // `>` is encountered.
     _parseEndOpenTag: function(tagName) {
-      /* FIXME: we probably don't need while() here, as the parser will
-       *        either cleanly terminate or throw a ParseError anyway? */
       while (!this.stream.end()) {
-        if (this.stream.eatWhile(/[A-Za-z\-]/)) {
+        if (this.stream.eat(nameStartChar) && this.stream.eatWhile(nameChar)) {
           this._parseAttribute(tagName);
         }
         else if (this.stream.eatSpace()) {


### PR DESCRIPTION
note that this does not fix the fact the the error thrown when the attribute fails parsing is the wrong error. This gets addressed in https://bugzilla.mozilla.org/show_bug.cgi?id=943432
