### PR TITLE
all slowparse errors have a cursor pos now

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,14 +39,15 @@ module.exports = function( grunt ) {
           "public/stylesheets/*.less"
         ]
       }
-    }      
+    }
     },
     jshint: {
       files: [
         "Gruntfile.js",
         "app.js",
         "lib/**/*.js",
-        "routes/**/*.js"
+        "routes/**/*.js",
+        "public/friendlycode/vendor/slowparse/slowparse.js"
       ]
     }
   });


### PR DESCRIPTION
This means errors are signalled the same for all cases, include two edge cases:
1. project is loaded but already has errors
2. a full-document-paste with erroneous code is performed (i.e. ctrl-a + ctrl-v)
