### PR TITLE
updated recess configuration to make LESS linting work

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,19 +27,32 @@ module.exports = function( grunt ) {
         src: [
           "public/learning_projects/**/*.css"
         ]
-      },
-      recess: {
-        dist: {
-         options: {
-            noOverQualifying: false,
-            noIDs: false,
-            strictPropertyOrder: false
-          },
-          src: [
-            "public/stylesheets/*.less"
-          ]
-        }
       }
+    },
+    lesslint: {
+      src: ["public/stylesheets/userbar-overrides.less"],
+        options: {
+          csslint: {
+            "adjoining-classes": false,
+            "box-model": false,
+            "box-sizing": false,
+            "bulletproof-font-face": false,
+            "compatible-vendor-prefixes": false,
+            "ids": false,
+            "important": false,
+            "outline-none": false,
+            "overqualified-elements": false,
+            "qualified-headings": false,
+            "regex-selectors": false,
+            "star-property-hack": false,
+            "underscore-property-hack": false,
+            "universal-selector": false,
+            "unique-headings": false,
+            "unqualified-attributes": false,
+            "vendor-prefix": false,
+            "zero-units": false
+          }
+        }
     },
     jshint: {
       options: {
@@ -67,8 +80,10 @@ module.exports = function( grunt ) {
   });
 
   grunt.loadNpmTasks( "grunt-contrib-csslint" );
+  grunt.loadNpmTasks( "grunt-lesslint" );
   grunt.loadNpmTasks( "grunt-contrib-jshint" );
   grunt.loadNpmTasks( "grunt-execute" );
 
-  grunt.registerTask( "default", [ "csslint", "jshint", "execute" ]);
+  grunt.registerTask( "default", [ "csslint", "jshint", "execute", "lesslint" ]);
 };
+

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "webmaker-analytics": "0.0.4",
     "webmaker-auth-client": "0.0.28",
     "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.8.tar.gz",
-    "webmaker-language-picker": "0.0.19"
+    "webmaker-language-picker": "0.0.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-contrib-csslint": "0.1.2",
     "grunt-contrib-jshint": "0.4.3",
     "grunt-execute": "0.1.5",
-    "grunt-recess": "0.3.3",
+    "grunt-lesslint": "1.1.0",
     "jsdom": "0.10.1"
   },
   "scripts": {

--- a/public/stylesheets/userbar-overrides.less
+++ b/public/stylesheets/userbar-overrides.less
@@ -2,9 +2,11 @@
 @import "webfonts";
 @import "buttons";
 @import "header";
-@import "@{language-bower-path}/webmaker-language-picker/styles/languages";
+@language-bower-path: "../../../bower_components"; // used from webmaker-language-picker/styles location
+@bower-path: "../../bower_components"; // used from public/stylesheets location
+@colors-path: "../../../public/stylesheets"; // used for colors.less from webmaker-language-picker/styles location
+@import "@{bower-path}/webmaker-language-picker/styles/languages";
 
-@language-bower-path: "../../bower_components";
 
 /***************************************************
 * Start New Language Picker


### PR DESCRIPTION
According to the bug https://bugzilla.mozilla.org/show_bug.cgi?id=916944  LESS linting for Thimble project wasn't performing correctly. To reproduce it, you have to execute 'grunt' in Thimble directory. It was showing "0 files lint free". In order to fix it file Gruntfile.js had to be updated to initialize RECESS module which does the LESS linting. Now it works and shows errors in *.less files.
