### PR TITLE
[bug959271] - Added CSP to thimble with allowed policies. Unsage eval is still present

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,6 +76,13 @@ require("./lib/extendnunjucks").extend(nunjucksEnv, nunjucks);
 
 nunjucksEnv.express(app);
 
+// adding Content Security Policy (CSP)
+app.use(middleware.addCSP({
+  personaHost: env.get('PERSONA_HOST'),
+  previewLoader: env.get('PREVIEW_LOADER'),
+  togetherJS: env.get('TOGETHERJS')
+}));
+
 app.use( i18n.middleware({
   supported_languages: env.get( "SUPPORTED_LANGS" ),
   default_lang: "en-US",

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -2,10 +2,76 @@ module.exports = function middlewareConstructor(env) {
 
   var metrics = require('./metrics')(env),
       utils = require("./utils"),
+      hood = require("hood"),
       emulate_s3 = env.get('S3_EMULATION') || !env.get('S3_KEY'),
       knox = emulate_s3 ? require("noxmox").mox : require("knox");
 
   return {
+    /**
+     * Content Security Policy HTTP response header
+     * helps you reduce XSS risks on modern browsers
+     * by declaring what dynamic resources are allowed
+     * to load via a HTTP Header.
+     */
+    addCSP: function ( options ) {
+      return hood.csp({
+        headers: [
+          "Content-Security-Policy-Report-Only"
+        ],
+        policy: {
+          'connect-src': [
+            "'self'",
+            "http://*.log.optimizely.com",
+            "https://*.log.optimizely.com",
+            "wss://hub.togetherjs.com"
+          ],
+          'default-src': [
+            "'self'"
+          ],
+          'frame-src': [
+            "'self'",
+            "https://docs.google.com",
+            options.previewLoader,
+            options.personaHost
+          ],
+          'font-src': [
+            "'self'",
+            "https://togetherjs.com"
+          ],
+          'img-src': [
+            "*"
+          ],
+          'media-src': [
+            "*"
+          ],
+          'script-src': [
+            "'self'",
+            "'unsafe-inline'", // Newrelic RUM
+            "'unsafe-eval'", // optimizely
+            "http://mozorg.cdn.mozilla.net",
+            "http://*.newrelic.com",
+            "https://*.newrelic.com",
+            "https://cdn.optimizely.com",
+            "https://ajax.googleapis.com",
+            "https://mozorg.cdn.mozilla.net",
+            "https://ssl.google-analytics.com",
+            "https://www.youtube.com",
+            "https://s.ytimg.com",
+            options.personaHost,
+            options.togetherJS
+          ],
+          'style-src': [
+            "'self'",
+            "'unsafe-inline'",
+            "http://mozorg.cdn.mozilla.net",
+            "https://ajax.googleapis.com",
+            "https://fonts.googleapis.com",
+            "https://mozorg.cdn.mozilla.net",
+            "https://togetherjs.com"
+          ]
+        }
+      });
+    },
     /**
      * The operation for the / route is special,
      * and never an edit or remix.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "express": "3.4.5",
     "habitat": "0.4.1",
     "helmet": "0.1.2",
+    "hood": "0.2.1",
     "htmlsanitizer": "0.0.2",
     "knox": "0.8.9",
     "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.21",


### PR DESCRIPTION
-> https://bugzilla.mozilla.org/show_bug.cgi?id=959271
