### PR TITLE
delicious digests

### DIFF
--- a/app.js
+++ b/app.js
@@ -254,7 +254,7 @@ app.post('/publish',
          middleware.sanitizeHTML,
          middleware.saveData(databaseAPI, env.get('HOSTNAME')),
          middleware.rewritePublishId(databaseAPI),
-         middleware.generateUrls(appName, env.get('S3'), env.get('USER_SUBDOMAIN')),
+         middleware.generateUrls(appName, env.get('S3'), env.get('USER_SUBDOMAIN'), databaseAPI),
          middleware.finalizeProject(env.get("HOSTNAME")),
          middleware.publishData(env.get('S3')),
          middleware.rewriteUrl,
@@ -269,30 +269,6 @@ app.post('/publish',
     });
   }
 );
-
-// Title verification function, used to make sure users are warned if
-// they try to save a project with a title that already exists, before
-// they actually press the "publish" button.
-app.post('/checktitle',
-         middleware.checkForAuth,
-         middleware.ensureMetaData,
-         function(req, res, next) {
-           req.body.metaData.title = req.body.title;
-           next();
-         },
-         middleware.checkPageOperation(databaseAPI),
-         middleware.checkTitleAvailability(databaseAPI),
-  function(req, res) {
-    if (res.locals.titleAvailability === 500) {
-      res.json({status: 500, reason: "an error occurred querying the database against your title"});
-    } else if (res.locals.titleAvailability === 409) {
-      res.json({status: 409, reason: "the title you have chosen is already in use"});
-    } else {
-      res.json({status: 200});
-    }
-  }
-);
-
 
 // Localized Strings
 app.get( '/strings/:lang?', i18n.stringsRoute( 'en-US' ) );

--- a/lib/base64.js
+++ b/lib/base64.js
@@ -1,0 +1,11 @@
+/**
+ * Wrapper for node's way of doing BASE64 encoding/decoding
+ */
+module.exports = {
+  encode: function (unencoded) {
+    return new Buffer(unencoded || '').toString('base64');
+  },
+  decode: function (encoded) {
+    return new Buffer(encoded || '', 'base64').toString('utf8');
+  }
+};

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -137,35 +137,6 @@ module.exports = function middlewareConstructor(env) {
     },
 
     /**
-     * Check whether a title is already taken
-     */
-    checkTitleAvailability: function(db, callback) {
-      return function(req, res, next) {
-        var options = {
-          userid: req.session.email,
-          title: utils.slugify(decodeURIComponent(req.body.metaData.title))
-        };
-        db.findBy(options, function(err, result) {
-          // genuine error
-          if (err) {
-            res.locals.titleAvailability = 500;
-          }
-          // "conflict": The request could not be completed due to a conflict
-          //             with the current state of the resource. This code is
-          //             only allowed in situations where it is expected that
-          //             the user might be able to resolve the conflict and
-          //             resubmit the request.
-          //
-          // second conditional: "title used by this user, but for another project"
-          else if (result && (req.body.pageOperation === "remix" || result.id != req.body.origin)) {
-            res.locals.titleAvailability = 409;
-          }
-          next();
-        });
-      };
-    },
-
-    /**
      * Publish a page to the database. If it's a publish by
      * the owning user, update. Otherwise, insert.
      */
@@ -246,52 +217,53 @@ module.exports = function middlewareConstructor(env) {
 
     rewritePublishId: function(db) {
       return function(req, res, next) {
-        // If the user hasn't defined a title, just use the publishId as-is
+        // If the user hasn't defined a title, the publishId
+        // does double duty as ersatz page title.
         if (!req.pageTitle) {
           req.pageTitle = req.publishId;
           return next();
         }
-
-        // is this an edit or supposed to be a new page?
-        var edit = (req.body.pageOperation === "edit");
-
-        db.count({
-          userid: req.session.email,
-          title: req.pageTitle
-        }, function(err, count) {
-          if (err) {
-            return next(utils.error(500, err));
-          }
-
-          if (!edit && count > 1) {
-            return next(utils.error(500, req.gettext("You already have a page titled") + ' "' + req.pageTitle + '" ' +
-                        req.gettext("you will have to choose a new title")));
-          }
-
-          next();
-        });
+        next();
       };
     },
 
-    generateUrls: function(appName, s3Url, domain) {
+    generateUrls: function(appName, s3Url, domain, db) {
       var url = require("url"),
           s3 = knox.createClient(s3Url);
 
       return function(req, res, next) {
-        var subdomain = req.session.user.username,
-            path = "/" + appName + "/" + req.pageTitle;
+        db.find(req.publishId, function(err, project) {
+          if (err) {
+            return next(err);
+          }
 
-        // Used by s3
-        req.publishLocation = "/" + subdomain + path;
-        req.s3Url = s3.url(req.publishLocation);
+          var subdomain = req.session.user.username,
+              idHash = utils.hashProjectId(req.publishId),
+              path = "/" + appName;
 
-        // Used for make API if USER_SUBDOMAIN exists
-        if (domain) {
-          domain = url.parse(domain);
-          req.customUrl = domain.protocol + "//" + subdomain + "." + domain.host + path;
-        }
+          // is this an old-style, project-hash-less URL?
+          // if so, we should not add the project hash now.
+          if (!project.url || (project.url && utils.usesIdHash(project.url))) {
+            path += "/" + idHash;
+          }
 
-        next();
+          // Do we have a real title? If so, add it
+          // to the URL. If not, don't bother.
+          if (req.pageTitle !== req.publishId) {
+            path += "/" + req.pageTitle;
+          }
+
+          req.publishLocation = "/" + subdomain + path;
+          req.s3Url = s3.url(req.publishLocation);
+
+          // Used for make API if USER_SUBDOMAIN exists
+          if (domain) {
+            domain = url.parse(domain);
+            req.customUrl = domain.protocol + "//" + subdomain + "." + domain.host + path;
+          }
+
+          next();
+        });
       };
     },
 
@@ -353,16 +325,11 @@ module.exports = function middlewareConstructor(env) {
               'Content-Type': 'text/html;charset=UTF-8'
             };
 
-        // TODO: proper mapping for old->new ids.
-        // See: https://bugzilla.mozilla.org/show_bug.cgi?id=862911
         var location = req.publishLocation,
-            // FIXME: Plan for S3 being down. This is not the ideal error handling,
-            //        but is a working stub in lieu of a proper solution.
-            // See: https://bugzilla.mozilla.org/show_bug.cgi?id=865738
+            s3Error = utils.error(500, "failure during publish step (error "+res.statusCode+")"),
             s3PublishError = utils.error(500, req.gettext("There was a problem publishing the page. Your page has been saved") +
                                        " with id "+req.publishId+", so you can edit it, but it could not be"+
-                                       " published to the web."),
-            s3Error = utils.error(500, "failure during publish step (error "+res.statusCode+")");
+                                       " published to the web.");
 
         // write data to S3
         s3.put(location + "_", headers)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,63 @@
-var http = require("http");
+var http = require("http"),
+    base64 = require("./base64");
 
-module.exports = {
+var Utils = {
+  // clean up titles for database-insertion
   slugify: require("uslug"),
 
-  error: function( code, msg ) {
-    var err = new Error( msg || http.STATUS_CODES[ code ]);
+  // top level error handler for our app
+  error: function(code, msg) {
+    var err = new Error(msg || http.STATUS_CODES[ ode]);
     err.status = code;
     return err;
+  },
+
+  // Generate a non-seqential, symmetrical hash for an id,
+  // (or reconstitute the id from an id's hash).
+  hashProjectId: function(code) {
+    var reversed = (typeof code === "string");
+    if (reversed) {
+      code = parseInt(base64.decode(code), 10);
+    }
+    code = code | 0;
+    var b0 = (code >>  0) & 0xFF,
+        b1 = (code >>  8) & 0xFF,
+        b2 = (code >> 16) & 0xFF,
+        b3 = (code >> 24) & 0xFF,
+        newcode = (b3 + (b2 << 8) + (b1 << 16) + (b0 << 24)) | 0;
+    return reversed ? newcode : base64.encode(""+newcode);
+  },
+
+  // determine whether a url follows the .../thimble/idhash/... pattern
+  usesIdHash: function(url) {
+    var base = "thimble/",
+        start = url.indexOf(base);
+
+    // this is currently unexpected, but let's future-proof:
+    if (start === -1) {
+      return false;
+    }
+
+    var check = url.substring(start + base.length),
+        delimited = check.indexOf("/"),
+        val;
+
+    // deal with .../thimble/HAIWOEHFAW as well as .../thimble/HAUWHEOIFD/my-page-title:
+    if(delimited > 0) {
+      check = check.substring(0, delimited);
+    }
+
+    // In theory, even if this isn't a true hash, someone could be using a title that is a
+    // base64-decodable string, so: check whether it decodes to a pure integer.
+    //
+    // If it does, statistics suggests this is, with very high probability, a hashId url.
+    try {
+      val = base64.decode(check);
+      return parseInt(val,10) == val; // note: intentional == to coerce number to string
+    }  catch (e) {}
+
+    return false;
   }
 };
+
+module.exports = Utils;

--- a/public/friendlycode/js/fc/ui/details-form.js
+++ b/public/friendlycode/js/fc/ui/details-form.js
@@ -19,42 +19,6 @@ define(['template!details-form', 'jquery', 'jquery-ui'], function (detailsFormHT
     return $('[name="' + name + '"]', $container);
   }
 
-  // Validation function that asks Thimble whether
-  // a particular title has already been saved before
-  // by the currently logged-in user.
-  function validateTitle(evt) {
-    var $error = $(".title-error.error-message"),
-        $button = $(".confirmation-button.yes-button"),
-        title = evt.target.value.toLowerCase(),
-        csrf_token = $("meta[name='csrf-token']").attr("content");
-
-    $.ajax({
-      type: "POST",
-      url: "/checktitle",
-      data: {
-        'title': title,
-        'pageOperation': $("meta[name='thimble-operation']").attr("content"),
-        'origin': $("meta[name='thimble-project-origin']").attr("content")
-      },
-      dataType: 'json',
-      beforeSend: function(request) {
-        request.setRequestHeader('X-CSRF-Token', csrf_token); // express.js uses a non-standard name for csrf-token
-      },
-      error: function(req) {
-        console.log("error while validating the title of your page");
-      },
-      success: function(response) {
-        if(response.status !== 200) {
-          $error.show();
-          $button.attr("disabled","disabled");
-        } else {
-          $error.hide();
-          $button.removeAttr("disabled");
-        }
-      }
-    });
-  }
-
   var DetailsForm = function (options) {
     var self = this;
     var defaults = {
@@ -135,9 +99,6 @@ define(['template!details-form', 'jquery', 'jquery-ui'], function (detailsFormHT
 
     // Store tags
     self.tags = [];
-
-    // bind change listener for the title
-    $input('title').on('input', validateTitle);
   };
 
   // construct a new document fragment for sandbox code evaluation
@@ -253,8 +214,6 @@ define(['template!details-form', 'jquery', 'jquery-ui'], function (detailsFormHT
       case 'title':
         val = val || currentVal || self.getCodeMirrorValue().find('title').text();
         $fieldInput.val(val);
-        // validate this title against Thimble's known titles for this user
-        validateTitle({ target: $fieldInput[0] });
         break;
       case 'thumbnail':
         val = val || currentVal || self.findMetaTagInfo('thumbnail')[0];


### PR DESCRIPTION
This patch changes the publish URL from the current

```
https://lolcat.makes.org/thimble/a-thing-I-like
```

to

```
https://lolcat.makes.org/thimble/Hj67Wh5EU/a-thing-I-like
```

where the url is "domain" + "tool" + "project id digest" + "vanity title". The vanity title doesn't really do much but it helps users identify content.

The patch has also been written to allow backward compatibility:
- new projects use the new URL scheme
- old projects use the old URL scheme
- remixing an old project uses the new scheme (due to being a new project)
- editing an old project uses the old scheme (so as not to break existing links on the interwebs)

There are two things worth thinking about here:
1. the project ID is currently a 32 bit integer. This leads to a fairly long project id digest, while only (heh, "only") allowing about 4 billion makes. We might be able to come up with a better scheme before landing, although the digest should not be a hash, as we don't want the headache of resolving hash collisions.
2. if people edit their "old style" project, and retitle it, should this still use the old scheme, or can we treat it as a republish, thus letting us use the new scheme?
