### PR TITLE
[hotfix] publish was not async-rewritten

### DIFF
--- a/public/friendlycode/js/fc/ui/publish.js
+++ b/public/friendlycode/js/fc/ui/publish.js
@@ -94,7 +94,7 @@ define([
 
           publisher.saveCode({
             html: sourceCode,
-            proxied: proxied,
+            proxied: proxied === sourceCode ? false : proxied,
             metaData: detailsForm.getValue(),
             dataProtector: dataProtector,
             published: saveAndPublish


### PR DESCRIPTION
the publish.js was still using URLProxy.proxyURL in a synchronous fashion, so it was never sending the right proxy-rewritten data (in fact, it was sending none). This rewrite moves the actual publish into the proxy callback, so that it happens at the right time.
