### PR TITLE
fixed live-preview of content with errors

### DIFF
--- a/public/friendlycode/js/fc/ui/editor-panes.js
+++ b/public/friendlycode/js/fc/ui/editor-panes.js
@@ -57,7 +57,7 @@ define(function(require) {
     });
     var preview = self.preview = LivePreview({
       codeMirror: codeMirror,
-      ignoreErrors: true,
+      ignoreErrors: options.ignoreErrors || false,
       previewArea: previewArea,
       previewLoader: options.previewLoader
     });


### PR DESCRIPTION
the update-preview-with-errors value was set to default true, instead of default false
