### PR TITLE
Wrap homepage footer elements in spans for discoverability by Pontoon

### DIFF
--- a/views/homepage/index.html
+++ b/views/homepage/index.html
@@ -239,12 +239,12 @@
     <footer>
       <div class="content-wrapper">
         <ul class="social-links">
-          <li><a title="{{ gettext("contactEmail") }}" class="email" href="mailto:thimble@mozillafoundation.org"><span class="icon"></span>{{ gettext("contactEmail") }}</a></li>
-          <li><a title="{{ gettext("contactTwitterTitle") }}" class="twitter" href="https://twitter.com/mozteach"><span class="icon"></span>{{ gettext("contactTwitter") }}</a></li>
-          <li><a title="{{ gettext("readTheDocs") }}" class="help" href="https://support.mozilla.org/{{ locale }}/products/webmaker/thimble"><span class="icon"></span>{{ gettext("readTheDocs") }}</a></li>
-          <li><a title="{{ gettext("contributeTitle") }}" class="github" href="https://github.com/mozilla/thimble.mozilla.org"><span class="icon"></span>{{ gettext("contribute") }}</a></li>
-          <li><a title="{{ gettext("termsOfUse") }}" class="terms" href="https://beta.webmaker.org/#/legal"><span class="icon"></span>{{ gettext("termsOfUse") }}</a></li>
-          <li><a title="{{ gettext("privacyPolicy") }}" class="privacy" href="https://www.mozilla.org/{{ locale }}/privacy/websites/"><span class="icon"></span>{{ gettext("privacyPolicy") }}</a></li>
+          <li><a title="{{ gettext("contactEmail") }}" class="email" href="mailto:thimble@mozillafoundation.org"><span class="icon"></span><span>{{ gettext("contactEmail") }}</span></a></li>
+          <li><a title="{{ gettext("contactTwitterTitle") }}" class="twitter" href="https://twitter.com/mozteach"><span class="icon"></span><span>{{ gettext("contactTwitter") }}</span></a></li>
+          <li><a title="{{ gettext("readTheDocs") }}" class="help" href="https://support.mozilla.org/{{ locale }}/products/webmaker/thimble"><span class="icon"></span><span>{{ gettext("readTheDocs") }}</span></a></li>
+          <li><a title="{{ gettext("contributeTitle") }}" class="github" href="https://github.com/mozilla/thimble.mozilla.org"><span class="icon"></span><span>{{ gettext("contribute") }}</span></a></li>
+          <li><a title="{{ gettext("termsOfUse") }}" class="terms" href="https://beta.webmaker.org/#/legal"><span class="icon"></span><span>{{ gettext("termsOfUse") }}</span></a></li>
+          <li><a title="{{ gettext("privacyPolicy") }}" class="privacy" href="https://www.mozilla.org/{{ locale }}/privacy/websites/"><span class="icon"></span><span>{{ gettext("privacyPolicy") }}</span></a></li>
         </ul>
         <div class="project-info">
           <a class="mozilla-logo" title="Mozilla" href="https://www.mozilla.org/{{ locale }}"><img alt="Mozilla" src="/img/mozilla-logo.svg" /></a>


### PR DESCRIPTION
Pontoon needs to be able to discover these text nodes and so we need to wrap them in container elements...I chose spans.