### PR TITLE
Add script to trigger build on Brackets for new strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,15 @@ node_js:
 - '4.3'
 sudo: false
 env:
-- L10N_LOCALE_SRC="locales" L10N_LOCALE_DEST="dist/locales"
+  global:
+  - L10N_LOCALE_SRC: locales
+  - L10N_LOCALE_DEST: dist/locales
+  - secure: EAbCzlvar10vLD/tkch8k7aeJj55AG5puDLIdj8CcqE9oBIplhZMMkEfLYCFYkubm0eIKMKnbSRqs/pddjebiQwGmjzWBN5Lhf6U3k7df36UB4WQwbisl88jxTKWmve4vLtYeJBuVQrr4eFxeB0OY0davbrmGItETG0ZaQYrJjY=
 cache:
   directories:
   - node_modules
-  - locale
+after_script:
+- bash ./scripts/localize-brackets.sh
 deploy:
   provider: heroku
   api_key:

--- a/scripts/localize-brackets.sh
+++ b/scripts/localize-brackets.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e # exit with nonzero exit code if anything fails
+
+SKIP="Skipping localization on Brackets:"
+
+# request body for the Travis API call to rebuild the latest commit in Brackets
+body='{
+  "request": {
+    "branch": "master",
+    "config": {
+      "env": {
+        "global": ["UPDATE_STRINGS=true"]
+      },
+      "script": "bash ./scripts/pull-new-strings.sh"
+    }
+  }
+}'
+
+# Exit the script if the build is for a pull request
+if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]
+then
+  # Get the last (current) commit's author
+  COMMIT_AUTHOR="$(git show --format=\"%cn\" --no-patch $TRAVIS_COMMIT)"
+
+  # Exit if the commit's author is not Pontoon
+  if [ "$COMMIT_AUTHOR" == "Mozilla Pontoon" ]
+  then
+    # Get the list of file changes
+    CHANGE_SET="$(git diff-tree --name-only --no-commit-id -r $TRAVIS_COMMIT)"
+
+    # Exit if there are no relevant string changes
+    if [[ "$CHANGE_SET" = *"editor.properties"* ]]
+    then
+      # Trigger travis build on brackets
+      # This uses an api token I generated once by running:
+      # `travis login && travis token` and then
+      # `travis encrypt <my_token>`
+      curl -s -X POST \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json" \
+        -H "Travis-API-Version: 3" \
+        -H "Authorization: token $TRAVIS_API_TOKEN" \
+        -d "$body" \
+        https://api.travis-ci.org/repo/mozilla%2Fbrackets/requests
+    else
+      echo "$SKIP No new changes to Brackets' strings"
+    fi
+  else
+    echo "$SKIP No new commits by Mozilla Pontoon"
+  fi
+else
+  echo "$SKIP Current branch isn't master"
+fi


### PR DESCRIPTION
This step will run every time a Travis build occurs and will check to see if the commit being built is a string change to the Brackets' string files. If it is, it triggers a rebuild on Brackets (which would pull the string changes and update the repo - writing code for that now).

One thing I'm not so sure of is the API token that I use in the travis request. I generated that locally using `travis login && travis token` according to https://docs.travis-ci.com/user/triggering-builds but I don't know if that is only for a session (would need to be regenerated every time) or should work for this case.