### PR TITLE
Updated style.less to remove remix bar when printing and open remix in new tab feature

### DIFF
--- a/public/resources/remix/style.less
+++ b/public/resources/remix/style.less
@@ -12,9 +12,9 @@
 }
 
 @media print {
-.details-bar, .collapsed, .cleanslate, .mouse-mode {
-display: none !important;
-}
+  .details-bar, .collapsed, .cleanslate, .mouse-mode {
+    display: none !important;
+  }
 }
 
 .details-bar {

--- a/public/resources/remix/style.less
+++ b/public/resources/remix/style.less
@@ -11,6 +11,12 @@
   font-style: normal;
 }
 
+@media print {
+.details-bar, .collapsed, .cleanslate, .mouse-mode {
+display: none !important;
+}
+}
+
 .details-bar {
   position: fixed !important;
   top: 0 !important;

--- a/views/project-remix-bar.html
+++ b/views/project-remix-bar.html
@@ -11,7 +11,7 @@
   <div class="details-bar-remix-button-wrapper">
     <a title="{{ gettext("remixWithThimble") }}"
        class="details-bar-remix-button"
-       href="{{ host }}/{{ lang }}/projects/{{ id }}/remix">{{ gettext("remix") }}
+       href="{{ host }}/{{ lang }}/projects/{{ id }}/remix" target="_blank">{{ gettext("remix") }}
     </a>
   </div>
   <div class="close-details-bar"><img src="{{ host }}/resources/remix/close-x.svg" /></div>


### PR DESCRIPTION
created commit for issue 1381 - https://github.com/mozilla/thimble.mozilla.org/issues/1381 - 
removed remix button when printing page in published preview - by adding print style to css/less.