### PR TITLE
Fix #1474 - Disable Fullscreen Button is not working

### DIFF
--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -956,8 +956,12 @@ body {
     top: 0;
   }
 
-  .filetree-pane-nav, .editor-pane-nav, .nav  {
+  .filetree-pane-nav, .editor-pane-nav, .nav, .toggle-auto-update {
     display: none !important;
+  }
+
+  .refresh-wrapper {
+    min-width: 0;
   }
 
   .bramble-toolbar {


### PR DESCRIPTION
I tried playing with the sizing, and doubling things fixes it.  The problem is the extra width of the newly added `auto` checkbox for refresh.

![screenshot 2016-05-04 11 30 05](https://cloud.githubusercontent.com/assets/427398/15019361/be840b4a-11eb-11e6-9fed-3c51f1ab408a.png)

r? @flukeout, @gideonthomas 