### PR TITLE
Fix #1311 - Renaming folders will no longer cause saving failed errors

### DIFF
--- a/public/editor/scripts/constants.js
+++ b/public/editor/scripts/constants.js
@@ -4,6 +4,7 @@ define(function() {
     PROJECT_META_KEY: "thimble-project-meta",
     SYNC_OPERATION_UPDATE: "update",
     SYNC_OPERATION_DELETE: "delete",
+    SYNC_OPERATION_RENAME_FOLDER: "rename-folder",
     // Default amount of time (ms) to wait between successful AJAX operations
     AJAX_DEFAULT_DELAY_MS: 10,
     // Default timeout period for AJAX requests so .fail() always gets called

--- a/public/editor/scripts/editor/js/fc/filesystem-sync.js
+++ b/public/editor/scripts/editor/js/fc/filesystem-sync.js
@@ -71,9 +71,14 @@ define(function(require) {
         Project.queueFileDelete(oldFilename);
       }
 
+      function handleFolderRename(paths) {
+        Project.queueFolderRename(paths);
+      }
+
       bramble.on("fileChange", handleFileChange);
       bramble.on("fileDelete", handleFileDelete);
       bramble.on("fileRename", handleFileRename);
+      bramble.on("folderRename", handleFolderRename);
 
       // Begin autosyncing
       syncManager.start();

--- a/public/editor/scripts/editor/js/fc/publisher.js
+++ b/public/editor/scripts/editor/js/fc/publisher.js
@@ -84,6 +84,7 @@ define(function(require) {
     bramble.on("fileChange", handleFileEvent);
     bramble.on("fileDelete", handleFileEvent);
     bramble.on("fileRename", handleFileEvent);
+    bramble.on("folderRename", handleFileEvent);
 
     dialog.buttons.publish.on("click", publisher.handlers.publish);
 

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -130,6 +130,11 @@ define(function(require) {
     PathCache.addItem(path, Constants.SYNC_OPERATION_DELETE);
   }
 
+  function queueFolderRename(paths, addToTop) {
+    logger("project", "queueFolderRename", paths);
+    PathCache.addItem(paths, Constants.SYNC_OPERATION_RENAME_FOLDER, addToTop);
+  }
+
   function init(projectDetails, host, callback) {
     _user = projectDetails.userID;
     _id = projectDetails.id;
@@ -316,6 +321,7 @@ define(function(require) {
     setSyncQueue: setSyncQueue,
     getSyncQueue: getSyncQueue,
     queueFileUpdate: queueFileUpdate,
-    queueFileDelete: queueFileDelete
+    queueFileDelete: queueFileDelete,
+    queueFolderRename: queueFolderRename
   };
 });

--- a/server/routes/projects/index.js
+++ b/server/routes/projects/index.js
@@ -36,6 +36,14 @@ module.exports = {
       middleware.validateRequest(["title"]),
       require("./rename").bind(app, config));
 
+    // Rename a folder in a project
+    app.put("/projects/:projectId/renamefolder",
+      middleware.checkForAuth,
+      middleware.setUserIfTokenExists,
+      middleware.setProject,
+      middleware.validateRequest(["paths", "dateUpdated"]),
+      require("./rename-folder").bind(app, config));
+
     // Publish an existing project for a user
     app.put("/projects/:projectId/publish",
       middleware.checkForAuth,

--- a/server/routes/projects/rename-folder.js
+++ b/server/routes/projects/rename-folder.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const request = require("request");
+
+const utils = require("../utils");
+
+module.exports = function(config, req, res) {
+  const user = req.user;
+  const project = req.project;
+  const dateUpdated = req.body.dateUpdated;
+  const uri = `${config.publishURL}/projects/${project.id}/updatepaths`;
+
+  request({
+    method: "PUT",
+    uri,
+    headers: {
+      "Authorization": `token ${user.token}`
+    },
+    body: req.body.paths,
+    json: true
+  }, function(err, response) {
+    if(err) {
+      console.error(`Failed to send request to ${uri} with: ${err}`);
+      res.sendStatus(500);
+      return;
+    }
+
+    if(response.statusCode !== 200) {
+      res.status(response.statusCode).send({error: response.body});
+      return;
+    }
+
+    project.date_updated = dateUpdated;
+
+    utils.updateProject(config, user, project, function(err, status) {
+      if(err) {
+        if(status === 500) {
+          res.sendStatus(500);
+        } else {
+          res.status(status).send({error: err});
+        }
+        return;
+      }
+
+      res.sendStatus(200);
+    });
+  });
+};


### PR DESCRIPTION
This is one part of a 3 part fix. The other two parts need to happen in publish.wm.org and brackets respectively. Here is the link to the Brackets PR - https://github.com/mozilla/brackets/pull/558.

This patch is blocked on the publish.wm.org patch landing first which will add a route to deal with folder renames.

The main purpose of this PR is to distinguish folder renames from file renames and handle them differently. The following changes have been made:
* A folder rename event will be listened for
* The path cache will be updated with a new folder rename entry which will have information about the old path, the new path, and all the file paths (stored as relative paths) contained in that folder that were affected by the rename (their abs paths have changed)
 * The format of the path cache was changed to accommodate this. Instead of it just being an array of objects, it is now an object with two properties - `files` and `folders`. The `files` property will store the array of objects as before. The `folders` property will store the folder rename operations (just that for now) as objects.
* When a sync is supposed to happen, the first thing that occurs is a transfer from the path cache to the sync queue. This was fairly straight-forward before. Now, we first look at all the folder renames that occurred and rename the file paths that are in the sync queue and the path cache accordingly. We do this in the order the folder rename data is stored (in the order that the folder renames occurred), so that we handle a folder being renamed twice. Only after this process do we transfer the path cache to the sync queue as before.
* Entries in the sync queue object for folder renames are different. Instead of being `"path": "folder-rename"` it is now an object like so:
```
"/path/after/rename": {
   "operation": "folder-rename",
   "persistedPath": "/path/stored/on/publish.wm.org",
   "changed" : [ list of relative file paths contained in the folder ]
}
```
* Although operations from the sync queue are still randomly chosen, folder rename operations are prioritized over other operations viz. update and delete
* A new route has been added to Thimble server which proxies the rename folder to publish.wm.org

@humphd r?