### PR TITLE
Fix spacing between publish icon and publish text

### DIFF
--- a/public/resources/stylesheets/userbar.less
+++ b/public/resources/stylesheets/userbar.less
@@ -186,6 +186,7 @@ body {
       vertical-align: middle;
       position: relative;
       top: -2px;
+      margin-right: 4px;
     }
 
     &:hover {

--- a/views/editor/userbar.html
+++ b/views/editor/userbar.html
@@ -107,9 +107,7 @@
 
     {% if username %}
       <div id="navbar-publish" class="nav-chunk">
-        <div title="{{ publishBtnTitle }}" id="navbar-publish-button">
-          <img src="/img/icon/publish.svg" class="icon-publish">
-          {{ gettext("publishBtn") }}
+        <div title="{{ publishBtnTitle }}" id="navbar-publish-button"><img src="/img/icon/publish.svg" class="icon-publish">{{ gettext("publishBtn") }}
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
Added margin to the right of the icon to space it from the text.
See Issue #1480 


First commit, Woo!