### PR TITLE
Enable bramble-watch-index.html extension

### DIFF
--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -189,3 +189,8 @@ ERROR_MOVING_FILE_DIALOG_HEADER=Move Error
 UNEXPECTED_ERROR_MOVING_FILE=An unexpected error occurred when attempting to move {0} to {1}
 # {0} is the name of the file/folder being moved and {1} is the name of the folder it is being moved to
 ERROR_MOVING_FILE_SAME_NAME=A file or folder with the name {0} already exists in {1}. Consider renaming either one to continue.
+
+# extensions/extra/bramble-watch-index.html
+
+INDEX_HTML_FILE_MISSING_DIALOG_TITLE=Warning - Missing index.html file
+INDEX_HTML_FILE_MISSING_DIALOG_MESSAGE=Projects without an index.html page will appear broken, for example: google.com/ actually refers to google.com/index.html. Add an index.html file or rename one of your current HTML files.

--- a/public/editor/scripts/editor/js/bramble-editor.js
+++ b/public/editor/scripts/editor/js/bramble-editor.js
@@ -14,7 +14,13 @@ define(function(require) {
       // Start loading the Bramble editor resources
       Bramble.load("#webmaker-bramble",{
         url: options.editorUrl,
-        hideUntilReady: true
+        hideUntilReady: true,
+        extensions: {
+          enable: [
+            // Watch and warn users on rename or delete of index.html
+            'bramble-watch-index.html'
+          ]
+        }
       });
 
       // Start loading the project files


### PR DESCRIPTION
This turns on the bramble-watch-index.html extension (depends on Bramble changes in https://github.com/mozilla/brackets/pull/564), and adds the necessary locale strings for Pontoon.

r? @gideonthomas 