### PR TITLE
Fix overlapping text/inputs in options menu.

### DIFF
--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -358,7 +358,6 @@ body {
   -webkit-box-shadow: 0 3px 9px rgba(0,0,0,0.24);
   -moz-box-shadow: 0 3px 9px rgba(0,0,0,0.24);
   box-shadow: 0 3px 9px rgba(0,0,0,0.24);
-  min-width: 240px;
   top: 65px;
   border-radius: 1px;
 
@@ -367,7 +366,7 @@ body {
     margin: 0;
     padding: 0;
     li {
-     padding: 20px;
+     padding: 20px 100px 20px 20px;
      position: relative;
     }
     li+li {

--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -385,7 +385,7 @@ body {
   width: 0;
   z-index: 1;
   top: -15px;
-  left: 109px;
+  left: calc(~"50% - 11px");
 }
 
 // Line wrap toggle


### PR DESCRIPTION
Closes #1427. Fixes the overlapping text/inputs on the editor options menu by removing the `min-width` and replacing it with padding large enough for the option toggles.

<img width="317" alt="menu3" src="https://cloud.githubusercontent.com/assets/409070/20581623/1e19125e-b1d2-11e6-8412-805b71666ea5.png">
<img width="308" alt="menu2" src="https://cloud.githubusercontent.com/assets/409070/20581625/1e1bbf18-b1d2-11e6-8bbd-db9399d002cb.png">
<img width="243" alt="menu1" src="https://cloud.githubusercontent.com/assets/409070/20581624/1e1a9d22-b1d2-11e6-97ab-e269c0cf3721.png">
<img width="317" alt="menu4" src="https://cloud.githubusercontent.com/assets/409070/20581645/3ce59b58-b1d2-11e6-8648-1d37d12fcfd1.png">
