### PR TITLE
fix locale redirection due to joining as filename

### DIFF
--- a/server/localize.js
+++ b/server/localize.js
@@ -35,10 +35,12 @@ module.exports = function localize(server, options) {
     let bestLanguage = bestlang(langPrefs, webmakerI18N.getSupportLanguages(), "en-US");
     let localizedUrl;
 
+    let orgUrl = req.originalUrl;
+
     if(knownLocales.indexOf(urlLocale) !== -1) {
-      localizedUrl = req.originalUrl.replace(urlLocale, bestLanguage);
+      localizedUrl = orgUrl.replace(urlLocale, bestLanguage);
     } else {
-      localizedUrl = path.join("/", bestLanguage, req.originalUrl);
+      localizedUrl = "/" + bestLanguage + "/" + (orgUrl === "/" ? "" : orgUrl);
     }
 
     res.redirect(307, localizedUrl);


### PR DESCRIPTION
URL redirects were being concatenated as if they were filenames, rather than being URL strings. These are two completely unrelated things, and the assumption broke the code on all OS that don't use `/` as standard path separator. This patch ensures that the URL is written correctly.