### PR TITLE
Fix #1604 - Use vagrant to run Thimble + all services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 .DS_Store
+.vagrant
 node_modules
-thimble.sqlite
 .env
 .heroku
-fakes3
-.htaccess
+*.log
+npm-debug.log.*
 locale/**/*.json
 public/stylesheets/userbar.css
 dist/
 client/
+mozilla.webmaker.org

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Setup
 
 - Node.js (version 4.6 or later) [[download](https://nodejs.org/en/download/)]
 - Vagrant (version 1.9 or later) [[download](https://www.vagrantup.com/downloads.html)]
+  - __Note:__ On Windows machines, you may need to restart your computer after installing Vagrant for it to be fully usable
 - Virtualbox (version 5.1 or later) [[download](https://www.virtualbox.org/wiki/Downloads)]
 
 The setup of Thimble can be divided into two distinct sections:
@@ -34,7 +35,7 @@ The setup of Thimble can be divided into two distinct sections:
 
 To fully use Thimble locally, you need to first setup Brackets locally first. This can be done by following the steps outlined below:
 
-- Fork and clone the [Brackets repository](https://github.com/mozilla/brackets)
+- Fork the [Brackets repository](https://github.com/mozilla/brackets) and then clone it to your local machine using `git clone --recursive https://github.com/<your_username>/brackets.git` (replace `<your_username>` with your Github username for the account you forked Brackets into)
 - In the cloned repository directory, run `npm install` to install the dependencies for Brackets
 - Run `npm run build` to create the built editor files that will be used by Thimble
 - Run `npm start` to start a server that will allow the editor to be accessed on [http://localhost:8000/src](http://localhost:8000/src)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Setup
 ### Requirements
 
 - Node.js (version 4.6 or later) [[download](https://nodejs.org/en/download/)]
+- Virtualbox (version 5.1 or later) [[download](https://www.virtualbox.org/wiki/Downloads)]
 - Vagrant (version 1.9 or later) [[download](https://www.vagrantup.com/downloads.html)]
   - __Note:__ On Windows machines, you may need to restart your computer after installing Vagrant for it to be fully usable
-- Virtualbox (version 5.1 or later) [[download](https://www.virtualbox.org/wiki/Downloads)]
 
 The setup of Thimble can be divided into two distinct sections:
 
@@ -55,7 +55,7 @@ For the first time, to start all dependent services and Thimble, simply run:
 ```
 vagrant up
 ```
-This process can take about 10-15 minutes as it needs to download all dependencies. Once you see a log that says `Express server listening on http://localhost:3500`, you can access Thimble on [http://localhost:3500](http://localhost:3500).
+This process can take a while depending on your internet connection speed as it needs to download all dependencies. Once you see a log that says `Express server listening on http://localhost:3500`, you can access Thimble on [http://localhost:3500](http://localhost:3500).
 
 You can now make changes to the Thimble source code on your system and they should be automatically reflected on [http://localhost:3500](http://localhost:3500).
 

--- a/README.md
+++ b/README.md
@@ -22,137 +22,49 @@ Thimble requires a modern web browser, and we recommend using Mozilla Firefox or
 Setup
 -----
 
-Thimble is non-trivial to run locally, due to its dependence on a number of other
-services.  In order to run Thimble, the following things are required. The following
-is an abbreviated guide to getting it all set up.  Please see each server's README for more details.
+### Requirements
 
-**You'll need**
-* Bramble
-* Thimble
-* Webmaker ID server
-* Webmaker Login Server
-* PostgreSQL Database
-* Webmaker Publishing Server
+- Node.js (version 4.6 or later) [[download](https://nodejs.org/en/download/)]
+- Vagrant (version 1.9 or later) [[download](https://www.vagrantup.com/downloads.html)]
+- Virtualbox (version 5.1 or later) [[download](https://www.virtualbox.org/wiki/Downloads)]
 
-## Installing the Parts
+The setup of Thimble can be divided into two distinct sections:
 
-Please note: On Windows, use copy instead of cp
+### Editor
 
-**Bramble**
-* Fork and clone https://github.com/mozilla/brackets
-* Run ``git submodule update --init`` to install submodules
-* Run ``npm install`` to install dependencies
-* Run `npm run build` to create `/dist` extensions and third-party libs
-* Run ``npm start`` to get a static server running on [http://localhost:8000/src](http://localhost:8000/src). You can try the demo version at [http://localhost:8000/src/hosted.html](http://localhost:8000/src/hosted.html)
-* For more information on setting up Bramble, refer to [Bramble Setup](https://github.com/mozilla/brackets#how-to-setup-bramble-brackets-in-your-local-machine)
+To fully use Thimble locally, you need to first setup Brackets locally first. This can be done by following the steps outlined below:
 
-**Thimble**
-* Fork and clone https://github.com/mozilla/thimble.mozilla.org
-* Run ``cp env.dist .env`` to create an environment file
-* Run ``npm install`` to install dependencies
-* Run ``npm run localize`` to generate the locale files
-* Run ``npm start`` to start the server
-* Once everything is ready and running, Thimble will be available at [http://localhost:3500/](http://localhost:3500/)
+- Fork and clone the [Brackets repository](https://github.com/mozilla/brackets)
+- In the cloned repository directory, run `npm install` to install the dependencies for Brackets
+- Run `npm run build` to create the built editor files that will be used by Thimble
+- Run `npm start` to start a server that will allow the editor to be accessed on [http://localhost:8000/src](http://localhost:8000/src)
+- You can find out more information about setting up Brackets locally by referring to the instructions [here](https://github.com/mozilla/brackets#how-to-setup-bramble-brackets-in-your-local-machine)
 
-**id.webmaker.org**
-* Clone https://github.com/mozilla/id.webmaker.org
-* Run ``cp sample.env .env`` to create an environment file
-* Run ``npm install`` to install dependencies
-* Run ``npm start`` to start the server
+### Thimble and Services
 
-**login.webmaker.org**
-* Clone https://github.com/mozilla/login.webmaker.org
-* Run ``npm install`` to install dependencies
-* Run ``cp env.sample .env`` to create an environment file
-* Run ``npm start`` the server
-* **Note:** login.webmaker.org needs a node version of 4.x only while all the other dependencies work with a node version of 4.x and above. We suggest installing [NVM](https://github.com/creationix/nvm) to allow the use of multiple versions of node.
+Thimble interacts with the Publish API (source managed in [publish.webmaker.org](https://github.com/mozilla/publish.webmaker.org)) to store users, projects, files and other content as well as publish user projects.
 
-**PostgreSQL**
-* Install Postgres via Homebrew
-  * Get Homebrew - http://brew.sh/
-  * Run ``brew install postgresql`` to install PostgreSQL once Homebrew is installed
-* Run ``initdb -D /usr/local/var/postgres`` to initialize PostreSQL
-  * If this already exists, run ``rm -rf /usr/local/var/postgres`` to remove it
-* Run ``postgres -D /usr/local/var/postgres`` to start the PostgreSQL server
-* Run ``createdb publish`` to create the Publish database
+For authentication and user management, Thimble uses Webmaker OAuth which consists of the Webmaker ID System (source managed in [id.webmaker.org](htps://github.com/mozilla/id.webmaker.org)) and the Webmaker Login API (source managed in [login.webmaker.org](https://github.com/mozilla/login.webmaker.org)).
 
-**publish.webmaker.org**
-* These steps assume you've followed the PostgreSQL steps above, including creating the publish database.
-* Clone https://github.com/mozilla/publish.webmaker.org
-* Run ``npm install`` to install dependencies
-* Run ``npm run env``
-* Run ``npm install knex -g`` to install knex
-* Run ``npm run knex`` to seed the publish database created earlier
-* Run ``npm start`` to run the server
+All three services along with Thimble are bundled together using Git subtrees and run together using Vagrant.
 
-## Getting Ready to Publish
-To publish locally, you'll need to do the following...
+The first step is to fork and clone Thimble and navigate to the cloned directory in a terminal shell.
 
-**1. Teach the ID server about the Publish server**
+For the first time, to start all dependent services and Thimble, simply run:
+```
+vagrant up
+```
+This process can take about 10-15 minutes as it needs to download all dependencies. Once you see a log that says `Express server listening on http://localhost:3500`, you can access Thimble on [http://localhost:3500](http://localhost:3500).
 
-* Run ``createdb webmaker_oauth_test`` to create a test database
-* In your id.webmaker.org folder
-  * Run ``node scripts/create-tables.js``
-  * Edit ``scripts/test-data.sql`` and replace it's contents with:
+You can now make changes to the Thimble source code on your system and they should be automatically reflected on [http://localhost:3500](http://localhost:3500).
 
-      ```sql
-        INSERT INTO clients VALUES
-          ( 'test',
-            'test',
-            '["password", "authorization_code"]'::jsonb,
-            '["code", "token"]'::jsonb,
-            'http://localhost:3500/callback' )
-      ```
+To stop running Thimble, simply press `Ctrl+C` twice.
 
-  * Run ``node scripts/test-data.js``
-    * You'll see a ``INSERT 0 1`` message if successful
-
-**2. Set up the local data folder**
-
-Instead of publishing to Amazon AWS, we'll be publishing to a local folder. Perform the following steps to set this up.
-* Run ``npm install -g http-server && mkdir -p /tmp/mox/test && cd /tmp/mox/test && http-server -p 8001``
-* Run ``cd /tmp/mox/test && http-server -p 8001`` to start the server
-* In your publish.webmaker.org folder
-  * Open the ``.env`` file
-  * Make sure that ``PUBLIC_PROJECT_ENDPOINT="localhost:8001"``` is set as shown here
-  * Restart publish server
-
-**3. Sign In**
-
-To publish locally, you'll need an account.
-* Go to [http://localhost:3000/account](http://localhost:3000/account)
-* Click ``Join Webmaker`` and complete the process, you can use a fake email
-* When you've created your account, click ``Set permanent password instead``
-  * This lets you authenticate your account without needing email
-* Go back to Thimble and Log In with your new account
-
-## Running the parts
-This is the list of commands to get each part up and running.
-
-* Thimble ``npm start``
-* Bramble ``npm start``
-* PostgreSQL Database ``postgres -D /usr/local/var/postgres``
-* Webmaker ID server ``npm start``
-* Webmaker Login Server ``npm start``
-* Webmaker Publishing Server ``npm start``
-* Local publish folder ``cd /tmp/mox/test && http-server -p 8001``
-
-Development additionals
------------------------
-
-We handle JS, HTML and CSS linting through grunt, which is very simple
-to set up if you don't have it installed already:
-
-```npm install -g grunt-cli```
-
-After this, simpy run ```grunt``` before commiting code and you should
-be good to go.
-
-Building the front-end
-----------------------
-
-Run `grunt requirejs:dist` to regenerate the front-end `dist/` folder if you so desire (it's
-only necessary in production). See `Gruntfile.js` for details.
+To restart Thimble again, run:
+```
+vagrant reload --provision
+```
+This will take a much shorter time to setup compared to the `vagrant up` command.
 
 Localization
 ----------------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision :shell, path: "scripts/start-services.sh"
+  config.vm.network :forwarded_port, host: 3500, guest: 3500 # Thimble
+  config.vm.network :forwarded_port, host: 5432, guest: 5432 # Postgres
+  config.vm.network :forwarded_port, host: 2015, guest: 2015 # publish.webmaker.org
+  config.vm.network :forwarded_port, host: 8001, guest: 8001 # Published projects
+  config.vm.network :forwarded_port, host: 1234, guest: 1234 # id.webmaker.org
+  config.vm.network :forwarded_port, host: 3000, guest: 3000 #login.webmaker.org
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,5 +12,6 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.cpus = 2
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
   end
 end

--- a/scripts/sql/oauth-setup.sql
+++ b/scripts/sql/oauth-setup.sql
@@ -1,0 +1,14 @@
+DO
+$do$
+BEGIN
+IF NOT EXISTS (SELECT * FROM clients WHERE client_id='test') THEN
+  INSERT INTO clients VALUES(
+    'test',
+    'test',
+    '["password", "authorization_code"]'::jsonb,
+    '["code", "token"]'::jsonb,
+    'http://localhost:3500/callback'
+  );
+END IF;
+END
+$do$

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -4,6 +4,8 @@ set -e
 PG_LOCATION="/usr/lib/postgresql/9.4/bin"
 DB_USERNAME="thimble"
 DB_PASSWORD="thimble"
+ID_WEBMAKER_ENV="POSTGRE_CONNECTION_STRING=postgres://$DB_USERNAME:$DB_PASSWORD@localhost:5432/webmaker_oauth_test HOST=0.0.0.0"
+PUBLISH_WEBMAKER_ENV="DATABASE_URL=postgres://$DB_USERNAME:$DB_PASSWORD@localhost:5432/publish"
 
 # --- Install OS level dependencies ---
 apt-get update -y
@@ -27,21 +29,27 @@ update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/
 apt-get install -y git # For id.webmaker.org
 npm install -g http-server --loglevel=error # For hosting published projects
 npm install -g node-gyp --loglevel=error # For bcrypt
+# We install the following dependencies globally since we disable .bin dependency links for npm install using --no-bin-links (due to Windows being unable to create symlinks) hence not allowing npm scripts to use the compiled dependencies directly
+npm install -g node-pre-gyp --loglevel=error # For login.webmaker.org sqlite3
+npm install -g autoless@0.1.7 webpack@1.7.3 --loglevel=error # For id.webmaker.org
+npm install -g knex@">=0.8.6 <0.9.0" --loglevel=error # For publish.webmaker.org
 # ---
 
 
 cd /vagrant
 ROOT="$(pwd)"
+SERVICES="$ROOT/services"
 
 # Create a database if it does not exist
 createdb() {
   local db_name=$1
 
   set +e # turn off exiting on error for the following statement since we handle the errors on our own
+  # Check if the database already exists
   su postgres -c "psql -lqt | cut -d \| -f 1 | grep -qcw $db_name"
   local exit_status=$?
   set -e
-  if [ "$exit_status" -ne 0 ]
+  if [ "$exit_status" -ne 0 ] # database does not exist if the exit status of grep was non-zero
   then
     su postgres -c "$PG_LOCATION/createdb $db_name"
   fi
@@ -50,10 +58,11 @@ createdb() {
 # Create a superuser if they do not exist
 createuser() {
   set +e # turn off exiting on error for the following statement since we handle the errors on our own
+  # Check if the user already exists
   su postgres -c "psql -tAc 'SELECT 1 FROM pg_roles WHERE rolname=\$\$$DB_USERNAME\$\$;' | grep -q 1"
   local exit_status=$?
   set -e
-  if [ "$exit_status" -ne 0 ]
+  if [ "$exit_status" -ne 0 ] # user does not exist if the exit status of grep was non-zero
   then
     su postgres -c "psql -c 'CREATE USER $DB_USERNAME WITH SUPERUSER PASSWORD \$\$$DB_PASSWORD\$\$;'"
   fi
@@ -77,7 +86,7 @@ cd services
 echo "Setting up login.webmaker.org"
 cd login.webmaker.org
 cp env.sample .env
-sudo npm install --loglevel=error # sudo needed for bcrypt permissions
+sudo npm install --no-bin-links --loglevel=error # sudo needed for bcrypt permissions
 cd ..
 # ---
 
@@ -86,7 +95,7 @@ cd ..
 echo "Setting up id.webmaker.org"
 cd id.webmaker.org
 cp sample.env .env
-npm install --unsafe-perm --loglevel=error
+npm install --no-bin-links --unsafe-perm --loglevel=error # --unsafe-perm needed to run with root privileges to avoid getting the error "cannot run in wd" thrown by one of the dependencies
 su postgres -c "node scripts/create-tables.js"
 su postgres -c "psql -d webmaker_oauth_test -f ../../scripts/sql/oauth-setup.sql"
 cd ..
@@ -97,7 +106,7 @@ cd ..
 echo "Setting up publish.webmaker.org"
 cd publish.webmaker.org
 npm run env
-npm install --loglevel=error
+npm install --no-bin-links --loglevel=error
 eval "DATABASE_URL=postgres://$DB_USERNAME:$DB_PASSWORD@localhost:5432/publish npm run migrate"
 cd ..
 mkdir -p /tmp/mox/test # Serve published projects from here
@@ -107,9 +116,9 @@ mkdir -p /tmp/mox/test # Serve published projects from here
 # --- Start all dependencies and Thimble in parallel subshells ---
 # All output from the 3 services are redirected to server.log files in their respective folders
 echo "Starting services"
-(cd "$ROOT/services/login.webmaker.org" && npm start > "$ROOT/services/login.webmaker.org/server.log" 2>&1) &
-(cd "$ROOT/services/id.webmaker.org" && eval "POSTGRE_CONNECTION_STRING=postgres://$DB_USERNAME:$DB_PASSWORD@localhost:5432/webmaker_oauth_test HOST=0.0.0.0 npm run server" > "$ROOT/services/id.webmaker.org/server.log" 2>&1) &
-(cd "$ROOT/services/publish.webmaker.org" && eval "DATABASE_URL=postgres://$DB_USERNAME:$DB_PASSWORD@localhost:5432/publish npm start" > "$ROOT/services/publish.webmaker.org/server.log" 2>&1) &
-(cd "$ROOT" && npm install --loglevel=error && npm start)
+(cd "$SERVICES/login.webmaker.org" && npm start > "$SERVICES/login.webmaker.org/server.log" 2>&1) &
+(cd "$SERVICES/id.webmaker.org" && eval "$ID_WEBMAKER_ENV npm run server" > "$SERVICES/id.webmaker.org/server.log" 2>&1) &
+(cd "$SERVICES/publish.webmaker.org" && eval "$PUBLISH_WEBMAKER_ENV npm start" > "$SERVICES/publish.webmaker.org/server.log" 2>&1) &
+(cd "$ROOT" && cp env.dist .env && npm install --no-bin-links --loglevel=error && npm start)
 wait
 # ---

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -e
+
+PG_LOCATION="/usr/lib/postgresql/9.4/bin"
+DB_USERNAME="thimble"
+DB_PASSWORD="thimble"
+
+# --- Install OS level dependencies ---
+apt-get update -y
+curl -sL https://deb.nodesource.com/setup_4.x | sh
+apt-get install -y nodejs
+# --- Postgres ---
+echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+apt-get install wget ca-certificates
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+apt-get update -y
+apt-get upgrade -y
+apt-get install -y postgresql-9.4
+# ---
+# --- login.webmaker.org bcrypt dependencies ---
+apt-get install -y python-software-properties
+add-apt-repository ppa:ubuntu-toolchain-r/test
+apt-get update -y
+apt-get install -y gcc-4.8 g++-4.8
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
+# ---
+apt-get install -y git # For id.webmaker.org
+npm install -g http-server --loglevel=error # For hosting published projects
+npm install -g node-gyp --loglevel=error # For bcrypt
+# ---
+
+
+cd /vagrant
+ROOT="$(pwd)"
+
+# Create a database if it does not exist
+createdb() {
+  local db_name=$1
+
+  set +e # turn off exiting on error for the following statement since we handle the errors on our own
+  su postgres -c "psql -lqt | cut -d \| -f 1 | grep -qcw $db_name"
+  local exit_status=$?
+  set -e
+  if [ "$exit_status" -ne 0 ]
+  then
+    su postgres -c "$PG_LOCATION/createdb $db_name"
+  fi
+}
+
+# Create a superuser if they do not exist
+createuser() {
+  set +e # turn off exiting on error for the following statement since we handle the errors on our own
+  su postgres -c "psql -tAc 'SELECT 1 FROM pg_roles WHERE rolname=\$\$$DB_USERNAME\$\$;' | grep -q 1"
+  local exit_status=$?
+  set -e
+  if [ "$exit_status" -ne 0 ]
+  then
+    su postgres -c "psql -c 'CREATE USER $DB_USERNAME WITH SUPERUSER PASSWORD \$\$$DB_PASSWORD\$\$;'"
+  fi
+}
+
+
+# --- Database Initialization ---
+echo "Setting up the database"
+# Create a user that can access the publish and id.webmaker.org databases
+createuser
+# Create the publish database if it doesn't already exist
+createdb "publish"
+# Create the id.webmaker.org database if it doesn't already exist
+createdb "webmaker_oauth_test"
+# ---
+
+cd services
+
+
+# --- login.webmaker.org setup ---
+echo "Setting up login.webmaker.org"
+cd login.webmaker.org
+cp env.sample .env
+sudo npm install --loglevel=error # sudo needed for bcrypt permissions
+cd ..
+# ---
+
+
+# --- id.webmaker.org setup and database setup ---
+echo "Setting up id.webmaker.org"
+cd id.webmaker.org
+cp sample.env .env
+npm install --unsafe-perm --loglevel=error
+su postgres -c "node scripts/create-tables.js"
+su postgres -c "psql -d webmaker_oauth_test -f ../../scripts/sql/oauth-setup.sql"
+cd ..
+# ---
+
+
+# --- publish.webmaker.org setup and database setup ---
+echo "Setting up publish.webmaker.org"
+cd publish.webmaker.org
+npm run env
+npm install --loglevel=error
+eval "DATABASE_URL=postgres://$DB_USERNAME:$DB_PASSWORD@localhost:5432/publish npm run migrate"
+cd ..
+mkdir -p /tmp/mox/test # Serve published projects from here
+# ---
+
+
+# --- Start all dependencies and Thimble in parallel subshells ---
+# All output from the 3 services are redirected to server.log files in their respective folders
+echo "Starting services"
+(cd "$ROOT/services/login.webmaker.org" && npm start > "$ROOT/services/login.webmaker.org/server.log" 2>&1) &
+(cd "$ROOT/services/id.webmaker.org" && eval "POSTGRE_CONNECTION_STRING=postgres://$DB_USERNAME:$DB_PASSWORD@localhost:5432/webmaker_oauth_test HOST=0.0.0.0 npm run server" > "$ROOT/services/id.webmaker.org/server.log" 2>&1) &
+(cd "$ROOT/services/publish.webmaker.org" && eval "DATABASE_URL=postgres://$DB_USERNAME:$DB_PASSWORD@localhost:5432/publish npm start" > "$ROOT/services/publish.webmaker.org/server.log" 2>&1) &
+(cd "$ROOT" && npm install --loglevel=error && npm start)
+wait
+# ---


### PR DESCRIPTION
Follow the instructions from the readme changes in this PR to see if you can setup Thimble.

Needs to be tested on Windows.