### PR TITLE
Fix #1534 - Publish button in some circumstances wouldn't trigger on click

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -330,7 +330,11 @@ define(function(require) {
 
     if (Project.getUser()) {
       //Publish button
-      $("#navbar-publish-button").click(showPublishDialog);
+      $("#navbar-publish-button").mousedown(function(e) {
+        if (e.which === 1) {
+          showPublishDialog();
+        }
+      });
       $("#publish-button-cancel").click(hidePublishDialog);
 
       publisher = new Publisher();


### PR DESCRIPTION
Originally, you were not able to trigger the 'Publish Dialog' window when moving the mouse and clicking the 'Publish' button (click-drag). You could also not trigger the window when clicking the very top edge of the button.

The change I made:
![publishmousedown](https://cloud.githubusercontent.com/assets/14262279/22393198/ca45d5d6-e4d0-11e6-9690-4cf6233f925f.png)

The 'Publish' button uses the mousedown event where it'll only show the dialog window if it is a left-click. You can move the mouse as fast as you want, click-drag, and the dialog will trigger as it is registered as a mousedown event and a left-click. This also seems to solve the top-edge issue where clicks would not register:
![publishtopedge](https://cloud.githubusercontent.com/assets/14262279/22393234/3a95bdce-e4d1-11e6-94c6-a396f65a6776.gif)
