### PR TITLE
Fix #1691 - Handle extra slashes in url construction during localization

### DIFF
--- a/server/localize.js
+++ b/server/localize.js
@@ -41,7 +41,7 @@ module.exports = function localize(server, options) {
       localizedUrl = orgUrl.replace(urlLocale, bestLanguage);
     } else {
       // This regex makes sure that orgUrl always begins with `/` and inserts one if it doesn't
-      localizedUrl = "/" + bestLanguage + orgUrl.replace(/^\/?/, "/");
+      localizedUrl = "/" + bestLanguage + orgUrl.replace(/^\/*/, "/");
     }
 
     res.redirect(307, localizedUrl);

--- a/server/localize.js
+++ b/server/localize.js
@@ -40,7 +40,8 @@ module.exports = function localize(server, options) {
     if(knownLocales.indexOf(urlLocale) !== -1) {
       localizedUrl = orgUrl.replace(urlLocale, bestLanguage);
     } else {
-      localizedUrl = "/" + bestLanguage + "/" + (orgUrl === "/" ? "" : orgUrl);
+      // This regex makes sure that orgUrl always begins with `/` and inserts one if it doesn't
+      localizedUrl = "/" + bestLanguage + orgUrl.replace(/^\/?/, "/");
     }
 
     res.redirect(307, localizedUrl);


### PR DESCRIPTION
Safe way to handle slashes while forming the url during localization