### PR TITLE
Fix #1333 - Dismisses Publish Dialog when link to Published project is clicked

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -333,6 +333,9 @@ define(function(require) {
       $("#navbar-publish-button").click(showPublishDialog);
       $("#publish-button-cancel").click(hidePublishDialog);
 
+      //Publish link
+      $("#link-publish-link").click(hidePublishDialog);
+
       publisher = new Publisher();
       publisher.init(bramble);
     } else {

--- a/views/editor/publish.html
+++ b/views/editor/publish.html
@@ -12,7 +12,7 @@
   <div id="publish-live" class="hide">
     <div>{{ gettext("publishShareLink") }}</div>
     <div id="publish-link">
-      <a title="{{ gettext("publishShareLinkTitle") }}" href="test"></a>
+      <a id="link-publish-link" title="{{ gettext("publishShareLinkTitle") }}" href="test"></a>
     </div>
 
     <div id="publish-changes" class="hide">


### PR DESCRIPTION
![publishlink](https://cloud.githubusercontent.com/assets/14262279/22536022/c86ee1da-e8cc-11e6-8882-ca1026572680.gif)

Just added id tag in publish.html and a click event to the link in bramble-ui-bridge.js like @gideonthomas suggested to someone else who no longer wanted to work on this issue.

Fixes #1333 