### PR TITLE
Fix #1635 - Fixed logged in user dropdown menu easier to click

### DIFF
--- a/public/resources/stylesheets/userbar.less
+++ b/public/resources/stylesheets/userbar.less
@@ -476,7 +476,6 @@ a.navbar-login:hover {
       margin: 0;
 
       li {
-        display: block;
         padding: 0;
 
         &:last-child {

--- a/public/resources/stylesheets/userbar.less
+++ b/public/resources/stylesheets/userbar.less
@@ -477,7 +477,7 @@ a.navbar-login:hover {
 
       li {
         display: block;
-        padding: 0px;
+        padding: 0;
 
         &:last-child {
           border-top: 1px solid #e9e9e9;

--- a/public/resources/stylesheets/userbar.less
+++ b/public/resources/stylesheets/userbar.less
@@ -477,7 +477,7 @@ a.navbar-login:hover {
 
       li {
         display: block;
-        padding: 12px;
+        padding: 0px;
 
         &:last-child {
           border-top: 1px solid #e9e9e9;
@@ -490,6 +490,8 @@ a.navbar-login:hover {
         a {
           text-decoration: none;
           color: black;
+          display: block;
+          padding: 12px;
 
           img {
             padding-right: 10px;


### PR DESCRIPTION
This resolve #1635  the issue found [here](https://github.com/mozilla/thimble.mozilla.org/issues/1635) which made the clickable padding of the logged in user menu not register. To remedy, I increased the padding of the link itself and decreased the padding of the `<li>` element which surrounded it. 