### PR TITLE
Fix #1627: Added ability to open a project in a new tab

### DIFF
--- a/public/editor/scripts/project-list.js
+++ b/public/editor/scripts/project-list.js
@@ -19,9 +19,7 @@ require.config({
 
 require(["jquery", "constants", "analytics", "moment"], function($, Constants, analytics, moment) {
   var projects = document.querySelectorAll("tr.bramble-user-project");
-  var username = encodeURIComponent($("#project-list").attr("data-username"));
   var locale = $("html")[0].lang;
-  var queryString = window.location.search;
   moment.locale($("meta[name='moment-lang']").attr("content"));
 
   function getElapsedTime(lastEdited) {

--- a/public/editor/scripts/project-list.js
+++ b/public/editor/scripts/project-list.js
@@ -34,9 +34,6 @@ require(["jquery", "constants", "analytics", "moment"], function($, Constants, a
     var projectSelector = "#" + project.getAttribute("id");
     var lastEdited = project.getAttribute("data-project-date_updated");
 
-    $(projectSelector + " > .project-title").on("click", function() {
-      window.location.href = "/" + locale + "/user/" + username + "/" + project.getAttribute("data-project-id") + queryString;
-    });
     $(projectSelector + " .project-information").text(getElapsedTime(lastEdited));
   });
 

--- a/public/editor/stylesheets/projects-style.less
+++ b/public/editor/stylesheets/projects-style.less
@@ -59,8 +59,8 @@ td.project-title {
   padding-left: 8px;
 }
 
-.project-title a{
-  color: #000000;
+.project-title a {
+  color: #000;
   text-decoration: none;
 }
 

--- a/public/editor/stylesheets/projects-style.less
+++ b/public/editor/stylesheets/projects-style.less
@@ -60,7 +60,7 @@ td.project-title {
 }
 
 .project-title a{
-  color:black;
+  color: #000000;
   text-decoration: none;
 }
 

--- a/public/editor/stylesheets/projects-style.less
+++ b/public/editor/stylesheets/projects-style.less
@@ -58,6 +58,12 @@ td.button-fill {
 td.project-title {
   padding-left: 8px;
 }
+
+.project-title a{
+  color:black;
+  text-decoration: none;
+}
+
 .project-information {
   font-size: 0.8em;
   color: #C6C6C6;

--- a/server/routes/projects/read.js
+++ b/server/routes/projects/read.js
@@ -79,10 +79,11 @@ module.exports = function(config, req, res, next) {
       csrf: req.csrfToken ? req.csrfToken() : null,
       HTTP_STATIC_URL: "/" + locale,
       username: user.username,
-      avatar : user.avatar,
+      avatar: user.avatar,
       projects: projects,
+      queryString: qs,
       editorHOST: config.editorHOST,
-      logoutURL : config.logoutURL
+      logoutURL: config.logoutURL
     };
 
     res.render("editor/projects.html", options);

--- a/views/editor/projects.html
+++ b/views/editor/projects.html
@@ -27,7 +27,8 @@
         {% endfor %}
         >
           <td class="project-title">
-            <a target="_self" href="/{{locale}}/user/{{username}}/{{project.id}}/{{queryString}}"> {{project.title}}
+            <a target="_self" href="/{{locale}}/user/{{username}}/{{project.id}}/{{queryString}}"> 
+              {{project.title}}
               <span class="project-information"></span>
             </a>
           </td>

--- a/views/editor/projects.html
+++ b/views/editor/projects.html
@@ -27,8 +27,8 @@
         {% endfor %}
         >
           <td class="project-title">
-            {{ project.title }}
-            <span class="project-information"></span>
+          <a target="_self" href="/{{locale}}/user/{{username}}/{{project.id}}/{{queryString}}"> {{project.title}}
+            <span class="project-information"></span></a>
           </td>
           <td>
             <div class="project-delete" title="{{ gettext("prjListDeleteProjectBtnTitle") }}">

--- a/views/editor/projects.html
+++ b/views/editor/projects.html
@@ -27,8 +27,9 @@
         {% endfor %}
         >
           <td class="project-title">
-          <a target="_self" href="/{{locale}}/user/{{username}}/{{project.id}}/{{queryString}}"> {{project.title}}
-            <span class="project-information"></span></a>
+            <a target="_self" href="/{{locale}}/user/{{username}}/{{project.id}}/{{queryString}}"> {{project.title}}
+              <span class="project-information"></span>
+            </a>
           </td>
           <td>
             <div class="project-delete" title="{{ gettext("prjListDeleteProjectBtnTitle") }}">


### PR DESCRIPTION
Now users should be able to open a project in a new tab.

![pic1](https://cloud.githubusercontent.com/assets/13225708/22835928/7a0a44a4-ef88-11e6-8ad1-ca2f7639ba5b.jpg)

In addition, since we use a regular link now, I see no point in keeping this [listener](https://github.com/mozilla/thimble.mozilla.org/blob/master/public/editor/scripts/project-list.js#L37-L39).  Let me know please whether I am right. 
