### PR TITLE
Add hover effect to autorefresh toggle in preview

### DIFF
--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -652,6 +652,13 @@ body {
       }
     }
 
+    &:hover {
+      color: rgba(0,0,0,.6);
+      .checkbox {
+        border: solid 1px rgba(0,0,0,.2);
+      }
+    }
+
     .checkbox {
       position: relative;
       width: 14px;


### PR DESCRIPTION
Addresses #1723 

At first I darkened the checkbox with the text:
![toggle_hover1](https://cloud.githubusercontent.com/assets/7986733/22861411/1b6eb5c4-f0e6-11e6-9490-728b2fb7386c.gif)

That didn't look quite right to me so I opted to only darken the text:
![toggle_hover2](https://cloud.githubusercontent.com/assets/7986733/22861414/2a7cf954-f0e6-11e6-864c-c3f373206eb1.gif)

Can switch back to the former if desired.