### PR TITLE
Fix #1719: Gear menu icon should keep hover state always when the....…

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-popupmenu.js
+++ b/public/editor/scripts/editor/js/fc/bramble-popupmenu.js
@@ -22,6 +22,7 @@ define(function(require) {
     self.close = function(e) {
       if(e) {
         e.stopPropagation();
+        $('#editor-pane-nav-options').css('opacity', '.5');
       }
       if(!self.showing) {
         return;
@@ -51,6 +52,7 @@ define(function(require) {
 
       if(!self.showing) {
         self.show();
+        $('#editor-pane-nav-options').css('opacity', '.7');
       } else {
         self.close();
       }


### PR DESCRIPTION
Added jquery to change css opacity property to .7 when gear icon is clicked.
Added jquery to change css opactity property back to .5 when gear icon is clicked again (when menu is closed).

This fixes issue number #[1719](https://github.com/mozilla/thimble.mozilla.org/issues/1719) 