### PR TITLE
added front end support for auto update preference to fix issue #1633

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -156,9 +156,10 @@ define(function(require) {
 
     // Set initial auto-refresh toggle to last known setting
     if(bramble.getAutoUpdate() === true) {
-        $(".refresh-wrapper").addClass("enabled");
     } else {
         $(".refresh-wrapper").removeClass("enabled");
+        bramble.disableAutoUpdate();
+        analytics.event("disableAutoUpdate");
     }
 
     // Preview auto-refresh toggle

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -154,6 +154,13 @@ define(function(require) {
       _inspectorEnabled = data.enabled;
     });
 
+    // Set initial auto-refresh toggle to last known setting
+    if(bramble.getAutoUpdate() === true) {
+        $(".refresh-wrapper").addClass("enabled");
+    } else {
+        $(".refresh-wrapper").removeClass("enabled");
+    }
+
     // Preview auto-refresh toggle
     $(".toggle-auto-update").on("click", function() {
       var refreshWrapper = $(".refresh-wrapper");

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -155,8 +155,7 @@ define(function(require) {
     });
 
     // Set initial auto-refresh toggle to last known setting
-    if(bramble.getAutoUpdate() === true) {
-    } else {
+    if(!bramble.getAutoUpdate()){
         $(".refresh-wrapper").removeClass("enabled");
         bramble.disableAutoUpdate();
         analytics.event("disableAutoUpdate");


### PR DESCRIPTION
I added some code to handle issue #1633 to the bramble-ui-bridge.js file. The back end for this is https://github.com/mozilla/brackets/pull/595.

This code just does the front end part, checking on load to see the preference stored for autoUpdate and changing the .refreshwrapper element to reflect that (by removing the checkmark if needed).

Final testing has yet to be done and will be done once the back end has been finalized as well.