### PR TITLE
Responsive UI in pane headers

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -57,7 +57,7 @@ define(function(require) {
   // Checks if the current element has enough room for everything in it
   // by checking if the last visible element is too far to the right.
   function hasEnoughRoom(el) {
-    var maxRight = el.width();
+    var maxRight = el[0].getBoundingClientRect().width - parseInt(el.css("padding-left"));
 
     // Finds the last visible first-order child
     var lastEl = false;
@@ -68,10 +68,12 @@ define(function(require) {
     });
 
     if(lastEl) {
-      var lastLeft = lastEl.position().left;
-      var lastWidth = lastEl.outerWidth();
+      var parentLeft = el[0].getBoundingClientRect().left;
+      var lastLeft = lastEl[0].getBoundingClientRect().left - parentLeft;
+      var lastWidth = lastEl[0].getBoundingClientRect().width;
       var lastRight = lastLeft + lastWidth;
-      return lastRight < maxRight;
+
+      return lastRight <= maxRight;
     } else {
       return true;
     }

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -42,7 +42,7 @@ define(function(require) {
     var itemCount = el.find("[data-adapt-order]").addClass("narrow").length;
 
     for(var i = itemCount; i > 0; i--) {
-      var item = el.find("[data-adapt-order="+i+"]")
+      var item = el.find("[data-adapt-order="+i+"]");
       item.removeClass("narrow");
       if(!hasEnoughRoom(el)) {
         item.addClass("narrow");

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -73,7 +73,7 @@ define(function(require) {
       var lastWidth = lastEl[0].getBoundingClientRect().width;
       var lastRight = lastLeft + lastWidth;
 
-      return lastRight <= maxRight;
+      return Math.round(lastRight) <= Math.round(maxRight);
     } else {
       return true;
     }

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -43,11 +43,7 @@ define(function(require) {
     el.find("[adapt-order]").addClass("narrow");
 
     for(var i = itemCount; i > 0; i--) {
-      if(hasEnoughRoom(el)) {
-        el.find("[adapt-order="+i+"]").removeClass("narrow");
-      } else {
-        break;
-      }
+      el.find("[adapt-order="+i+"]").removeClass("narrow");
       if(!hasEnoughRoom(el)) {
         el.find("[adapt-order="+i+"]").addClass("narrow");
       }
@@ -69,11 +65,12 @@ define(function(require) {
 
     if(lastEl) {
       var parentLeft = el[0].getBoundingClientRect().left;
-      var lastLeft = lastEl[0].getBoundingClientRect().left - parentLeft;
-      var lastWidth = lastEl[0].getBoundingClientRect().width;
-      var lastRight = lastLeft + lastWidth;
+      var lastElBounds = lastEl[0].getBoundingClientRect();
+      var lastElLeft = lastElBounds.left - parentLeft;
+      var lastElWidth = lastElBounds.width;
+      var lastElRight = lastElLeft + lastElWidth;
 
-      return Math.round(lastRight) <= Math.round(maxRight);
+      return Math.round(lastElRight) <= Math.round(maxRight);
     } else {
       return true;
     }

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -441,6 +441,7 @@ define(function(require) {
     });
 
     $("#spinner-container").fadeOut();
+    adaptLayout();
   }
 
   return {

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -39,13 +39,13 @@ define(function(require) {
   // Checks if there is enough room for all of the elements inside it
   // Adds a 'narrow' class, in priority order, when there isn't.
   function adaptElement(el){
-    var itemCount = el.find("[adapt-order]").length;
-    el.find("[adapt-order]").addClass("narrow");
+    var itemCount = el.find("[data-adapt-order]").addClass("narrow").length;
 
     for(var i = itemCount; i > 0; i--) {
-      el.find("[adapt-order="+i+"]").removeClass("narrow");
+      var item = el.find("[data-adapt-order="+i+"]")
+      item.removeClass("narrow");
       if(!hasEnoughRoom(el)) {
-        el.find("[adapt-order="+i+"]").addClass("narrow");
+        item.addClass("narrow");
       }
     }
   }

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -12,7 +12,7 @@ define(function(require) {
   var _escKeyHandler;
 
   var adapting = false;
-  var adaptTimeout = 200; // How often we adapt editor bar layout
+  var adaptTimeoutMS = 200; // How often we adapt editor bar layout
 
   function updateLayout(data) {
     $(".filetree-pane-nav").width(data.sidebarWidth);
@@ -25,7 +25,7 @@ define(function(require) {
       adaptLayout();
       setTimeout(function(){
         adapting = false;
-      },adaptTimeout)
+      },adaptTimeoutMS);
     }
   }
 

--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -66,8 +66,8 @@ body {
   float: left;
   overflow: hidden;
 
-  .nav-container {
-    min-width: 150px;
+  .narrow {
+    display: none;
   }
 }
 
@@ -199,20 +199,38 @@ body {
   color: #757575;
   float: left;
   overflow: hidden;
+  position: relative;
 
   .nav-container {
-    min-width: 385px;
+    white-space: nowrap;
     padding-right: 16px;
+    min-width: auto;
+    position: relative;
+  }
+
+  .editor-pane-nav-title {
+    color: white;
+    font-weight: bold;
+    opacity: 0.45;
+    filter: alpha(opacity=45);
+    margin-right: 10px;
+    .vertical-align;
+
+    &.narrow {
+      display: none;
+    }
+  }
+
+  #editor-pane-nav-filename {
+    margin-right: 10px;
+    font-weight: 600;
+
+    &.narrow {
+      display: none;
+    }
   }
 }
 
-.editor-pane-nav-title {
-  color: white;
-  font-weight: bold;
-  opacity: 0.45;
-  filter: alpha(opacity=45);
-  .vertical-align;
-}
 
 #editor-pane-nav-fileview {
   width: 25px;
@@ -250,6 +268,7 @@ body {
   padding: 5px 10px 5px 10px;
   display: inline-block;
   position: relative;
+
   .icon;
 
   img {
@@ -268,6 +287,16 @@ body {
     top: -1px;
     opacity: 0.5;
     filter: alpha(opacity=50);
+  }
+
+  &.narrow {
+    padding: 5px;
+    width: 20px;
+    text-align: center;
+
+    span {
+      display: none;
+    }
   }
 
   &:hover {
@@ -565,6 +594,10 @@ body {
     font-weight: bold;
   }
 
+  &.narrow {
+    display: none;
+  }
+
   &.has-toggle {
 
     .preview-pane-nav-title {
@@ -591,6 +624,14 @@ body {
   position: relative;
   vertical-align: middle;
   min-width: 110px;
+
+  &.narrow {
+    .toggle-auto-update {
+      display: none;
+    }
+    min-width: auto;
+  }
+
 
   #preview-pane-nav-refresh {
     z-index: 2;
@@ -713,8 +754,8 @@ body {
   .flex-container;
 
   .nav-container {
-    min-width: 400px;
     padding: 0 16px 0 20px;
+    white-space: nowrap;
   }
 }
 
@@ -731,7 +772,11 @@ body {
   padding: 5px;
   border-radius: 50%;
   position: relative;
-  margin-right: 10px;
+  margin-right: 6px;
+
+  &.narrow {
+    display: none;
+  }
 
   .icon-wrapper {
     position: absolute;
@@ -866,6 +911,7 @@ body {
   box-sizing: border-box;
   padding-right: 20px;
   padding-left: 20px;
+  white-space: nowrap;
 
   .flex-vertical-align;
 }
@@ -986,7 +1032,6 @@ body {
       border-radius: 1px;
 
       .nav-container {
-        min-width: 0;
         padding: 0 12px;
 
         .pull-right {

--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -211,19 +211,11 @@ body {
     filter: alpha(opacity=45);
     margin-right: 10px;
     .vertical-align;
-
-    &.narrow {
-      display: none;
-    }
   }
 
   #editor-pane-nav-filename {
     margin-right: 10px;
     font-weight: 600;
-
-    &.narrow {
-      display: none;
-    }
   }
 }
 
@@ -261,8 +253,7 @@ body {
   background-color: #2B2B2B;
   border-radius: 25px;
   height: 20px;
-  padding: 5px 10px 5px 10px;
-  display: inline-block;
+  padding: 5px 8px 5px 7px;
   position: relative;
 
   .icon;
@@ -283,16 +274,6 @@ body {
     top: -1px;
     opacity: 0.5;
     filter: alpha(opacity=50);
-  }
-
-  &.narrow {
-    padding: 5px;
-    width: 20px;
-    text-align: center;
-
-    span {
-      display: none;
-    }
   }
 
   &:hover {
@@ -328,7 +309,6 @@ body {
   padding: 5px;
   border-radius: 50%;
   margin-left: 6px;
-  margin-right: 6px;
   position: relative;
   .icon;
 
@@ -360,10 +340,12 @@ body {
 
 
 #editor-pane-nav-options {
-  .icon;
   opacity: 0.5;
   filter: alpha(opacity=50);
   padding: 4px;
+  margin-left: 6px;
+
+  .icon;
 
   img {
       width: 22px;
@@ -590,10 +572,6 @@ body {
     font-weight: bold;
   }
 
-  &.narrow {
-    display: none;
-  }
-
   &.has-toggle {
 
     .preview-pane-nav-title {
@@ -619,12 +597,6 @@ body {
 .refresh-wrapper {
   position: relative;
   vertical-align: middle;
-
-  &.narrow {
-    .toggle-auto-update {
-      display: none;
-    }
-  }
 
 
   #preview-pane-nav-refresh {
@@ -765,11 +737,7 @@ body {
   padding: 5px;
   border-radius: 50%;
   position: relative;
-  margin-right: 6px;
-
-  &.narrow {
-    display: none;
-  }
+  margin-left: 6px;
 
   .icon-wrapper {
     position: absolute;
@@ -808,6 +776,7 @@ body {
   background: #f9f9f9;
   border-radius: 30px;
   height: 30px;
+  margin-left: 6px;
 
   img {
     width: 20px;
@@ -847,7 +816,7 @@ body {
 
 .fullscreen-preview-toggle {
   margin-left: 8px;
-  line-height: 18px;
+  line-height: 19px;
   cursor: pointer;
 
   .disable-fullscreen {
@@ -896,6 +865,7 @@ body {
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  min-height: 1px;
 }
 
 .nav-container {
@@ -905,6 +875,10 @@ body {
   padding-right: 20px;
   padding-left: 20px;
   white-space: nowrap;
+
+  .narrow {
+    display: none
+  }
 
   .flex-vertical-align;
 }

--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -202,7 +202,6 @@ body {
 
   .nav-container {
     white-space: nowrap;
-    min-width: initial;
   }
 
   .editor-pane-nav-title {
@@ -620,13 +619,11 @@ body {
 .refresh-wrapper {
   position: relative;
   vertical-align: middle;
-  min-width: 110px;
 
   &.narrow {
     .toggle-auto-update {
       display: none;
     }
-    min-width: initial;
   }
 
 
@@ -1002,10 +999,6 @@ body {
     display: none !important;
   }
 
-  .refresh-wrapper {
-    min-width: 0;
-  }
-
   .bramble-toolbar {
     position: fixed;
     top: 10px;
@@ -1024,7 +1017,6 @@ body {
       top: 4px;
       right: 8px;
       box-sizing: border-box;
-      min-width: 0;
       border-radius: 1px;
 
       .nav-container {

--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -202,7 +202,7 @@ body {
 
   .nav-container {
     white-space: nowrap;
-    min-width: auto;
+    min-width: initial;
   }
 
   .editor-pane-nav-title {
@@ -626,7 +626,7 @@ body {
     .toggle-auto-update {
       display: none;
     }
-    min-width: auto;
+    min-width: initial;
   }
 
 

--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -199,12 +199,10 @@ body {
   color: #757575;
   float: left;
   overflow: hidden;
-  position: relative;
 
   .nav-container {
     white-space: nowrap;
     min-width: auto;
-    position: relative;
   }
 
   .editor-pane-nav-title {

--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -203,7 +203,6 @@ body {
 
   .nav-container {
     white-space: nowrap;
-    padding-right: 16px;
     min-width: auto;
     position: relative;
   }
@@ -754,7 +753,6 @@ body {
   .flex-container;
 
   .nav-container {
-    padding: 0 16px 0 20px;
     white-space: nowrap;
   }
 }

--- a/views/editor/nav-options.html
+++ b/views/editor/nav-options.html
@@ -3,7 +3,7 @@
   <!-- FILE TREE -->
   <div class="filetree-pane-nav hide">
     <div class="nav-container">
-      <div class="filetree-pane-nav-title">
+      <div adapt-order="1" class="filetree-pane-nav-title">
         {{ gettext("navFiles") }}
       </div>
 
@@ -30,20 +30,21 @@
     </div>
   </div>
 
-  <!-- LEFT SIDE -->
+  <!-- LEFT SIDE - Editor -->
   <div class="editor-pane-nav">
+
     <div class="nav-container">
       <div title="{{ gettext("navExpandFileTrayIconTitle") }}" id="editor-pane-nav-fileview">
         <div></div>
       </div>
 
-      <span class="editor-pane-nav-title">{{ gettext("navEditor") }}</span>
-      <span>&nbsp;-&nbsp;</span>
-      <span id="editor-pane-nav-filename"></span>
+      <span adapt-order="2" class="editor-pane-nav-title">{{ gettext("navEditor") }}</span>
+
+      <span adapt-order="3" id="editor-pane-nav-filename"></span>
 
       <div class="flex-container pull-right">
 
-        <div title="{{ gettext("navUndoTitle") }}" id="editor-pane-nav-undo">
+        <div adapt-order="1" title="{{ gettext("navUndoTitle") }}" id="editor-pane-nav-undo">
           <img src="/img/icon/undo.svg">
           <span>{{ gettext("navUndo") }}</span>
         </div>
@@ -51,6 +52,7 @@
         <div title="{{ gettext("navRedoIconTitle") }}" id="editor-pane-nav-redo">
           <img src="/img/icon/redo.svg">
         </div>
+
           <div title="{{ gettext("navEditorOptionsIconTitle") }}" id="editor-pane-nav-options">
             <img src="/img/icon/gear-white.svg">
           </div>
@@ -98,15 +100,16 @@
     </div>
   </div>
 
-  <!-- RIGHT SIDE -->
+  <!-- RIGHT SIDE - Preview & Tutorial -->
+
   <div class="preview-pane-nav">
     <div class="nav-container">
-      <div class="preview-tutorial-toggle">
+      <div class="preview-tutorial-toggle" adapt-order="1">
         <span title="{{ gettext("navPreviewTitle") }}" id="preview-title" class="preview-pane-nav-title preview-title-highlighted">{{ gettext("navPreview") }}</span>
         <span title="{{ gettext("navViewTutorialTitle") }}" id="tutorial-title" class="preview-pane-nav-title hide">{{ gettext("navViewTutorial") }}</span>
       </div>
 
-      <div class="refresh-wrapper enabled">
+      <div class="refresh-wrapper enabled"  adapt-order="2">
         <div title="{{ gettext("navRefreshPreviewIconTitle") }}" id="preview-pane-nav-refresh">
           <img src="/img/icon/refresh.svg">
         </div>
@@ -119,7 +122,7 @@
       </div>
 
       <div class="flex-container pull-right">
-        <div title="{{ gettext("navDOMElementInspectorIconTitle") }}" id="preview-pane-nav-inspector">
+        <div adapt-order="3" title="{{ gettext("navDOMElementInspectorIconTitle") }}" id="preview-pane-nav-inspector">
           <div class="icon-wrapper"></div>
         </div>
         <div class="preview-device-toggle">

--- a/views/editor/nav-options.html
+++ b/views/editor/nav-options.html
@@ -3,7 +3,7 @@
   <!-- FILE TREE -->
   <div class="filetree-pane-nav hide">
     <div class="nav-container">
-      <div adapt-order="1" class="filetree-pane-nav-title">
+      <div data-adapt-order="1" class="filetree-pane-nav-title">
         {{ gettext("navFiles") }}
       </div>
 
@@ -38,13 +38,13 @@
         <div></div>
       </div>
 
-      <span adapt-order="2" class="editor-pane-nav-title">{{ gettext("navEditor") }}</span>
+      <span data-adapt-order="2" class="editor-pane-nav-title">{{ gettext("navEditor") }}</span>
 
-      <span adapt-order="3" id="editor-pane-nav-filename"></span>
+      <span data-adapt-order="3" id="editor-pane-nav-filename"></span>
 
       <div class="flex-container pull-right">
 
-        <div adapt-order="1" title="{{ gettext("navUndoTitle") }}" id="editor-pane-nav-undo">
+        <div data-adapt-order="1" title="{{ gettext("navUndoTitle") }}" id="editor-pane-nav-undo">
           <img src="/img/icon/undo.svg">
           <span>{{ gettext("navUndo") }}</span>
         </div>
@@ -104,12 +104,12 @@
 
   <div class="preview-pane-nav">
     <div class="nav-container">
-      <div class="preview-tutorial-toggle" adapt-order="1">
+      <div class="preview-tutorial-toggle" data-adapt-order="1">
         <span title="{{ gettext("navPreviewTitle") }}" id="preview-title" class="preview-pane-nav-title preview-title-highlighted">{{ gettext("navPreview") }}</span>
         <span title="{{ gettext("navViewTutorialTitle") }}" id="tutorial-title" class="preview-pane-nav-title hide">{{ gettext("navViewTutorial") }}</span>
       </div>
 
-      <div class="refresh-wrapper enabled"  adapt-order="2">
+      <div class="refresh-wrapper enabled"  data-adapt-order="2">
         <div title="{{ gettext("navRefreshPreviewIconTitle") }}" id="preview-pane-nav-refresh">
           <img src="/img/icon/refresh.svg">
         </div>
@@ -122,7 +122,7 @@
       </div>
 
       <div class="flex-container pull-right">
-        <div adapt-order="3" title="{{ gettext("navDOMElementInspectorIconTitle") }}" id="preview-pane-nav-inspector">
+        <div data-adapt-order="3" title="{{ gettext("navDOMElementInspectorIconTitle") }}" id="preview-pane-nav-inspector">
           <div class="icon-wrapper"></div>
         </div>
         <div class="preview-device-toggle">

--- a/views/editor/nav-options.html
+++ b/views/editor/nav-options.html
@@ -44,57 +44,57 @@
 
       <div class="flex-container pull-right">
 
-        <div data-adapt-order="1" title="{{ gettext("navUndoTitle") }}" id="editor-pane-nav-undo">
+        <div data-adapt-order="5" title="{{ gettext("navUndoTitle") }}" id="editor-pane-nav-undo">
           <img src="/img/icon/undo.svg">
-          <span>{{ gettext("navUndo") }}</span>
+          <span data-adapt-order="1">{{ gettext("navUndo") }}</span>
         </div>
 
-        <div title="{{ gettext("navRedoIconTitle") }}" id="editor-pane-nav-redo">
+        <div data-adapt-order="4" title="{{ gettext("navRedoIconTitle") }}" id="editor-pane-nav-redo">
           <img src="/img/icon/redo.svg">
         </div>
 
-          <div title="{{ gettext("navEditorOptionsIconTitle") }}" id="editor-pane-nav-options">
-            <img src="/img/icon/gear-white.svg">
-          </div>
-          <div id="editor-pane-nav-options-menu" class="hide">
-            <ul>
-              <li>
-                <span>{{ gettext("navTextSize") }}</span>
-                <div class="text-size-ui">
-                  <div title="{{ gettext("navDecreaseTextSizeIconTitle") }}" id="editor-pane-nav-decrease-font" class="font-size-button"></div>
-                  <div title="{{ gettext("navIncreaseTextSizeIconTitle") }}" id="editor-pane-nav-increase-font" class="font-size-button"></div>
+        <div data-adapt-order="6" title="{{ gettext("navEditorOptionsIconTitle") }}" id="editor-pane-nav-options">
+          <img src="/img/icon/gear-white.svg">
+        </div>
+        <div id="editor-pane-nav-options-menu" class="hide">
+          <ul>
+            <li>
+              <span>{{ gettext("navTextSize") }}</span>
+              <div class="text-size-ui">
+                <div title="{{ gettext("navDecreaseTextSizeIconTitle") }}" id="editor-pane-nav-decrease-font" class="font-size-button"></div>
+                <div title="{{ gettext("navIncreaseTextSizeIconTitle") }}" id="editor-pane-nav-increase-font" class="font-size-button"></div>
+              </div>
+            </li>
+            <li>
+              <span>{{ gettext("navColorTheme") }}</span>
+              <div id="editor-pane-nav-toggle-theme">
+                <div id="theme-active"></div>
+                <div title="{{ gettext("navDarkThemeIconTitle") }}" id="theme-dark">
+                  <img id="moon-white" src="/img/icon/theme-moon-white.svg" width="15px" height="15px">
+                  <img id="moon-green" class="hide" src="/img/icon/theme-moon-green.svg" width="15px" height="15px">
                 </div>
-              </li>
-              <li>
-                <span>{{ gettext("navColorTheme") }}</span>
-                <div id="editor-pane-nav-toggle-theme">
-                  <div id="theme-active"></div>
-                  <div title="{{ gettext("navDarkThemeIconTitle") }}" id="theme-dark">
-                    <img id="moon-white" src="/img/icon/theme-moon-white.svg" width="15px" height="15px">
-                    <img id="moon-green" class="hide" src="/img/icon/theme-moon-green.svg" width="15px" height="15px">
-                  </div>
-                  <div title="{{ gettext("navLightThemeIconTitle") }}" id="theme-light">
-                    <img id="sun-white" class="hide" src="/img/icon/theme-sun-white.svg" width="20px" class="hide" height="20px">
-                    <img id="sun-green" src="/img/icon/theme-sun-green.svg" width="20px" height="20px">
-                  </div>
+                <div title="{{ gettext("navLightThemeIconTitle") }}" id="theme-light">
+                  <img id="sun-white" class="hide" src="/img/icon/theme-sun-white.svg" width="20px" class="hide" height="20px">
+                  <img id="sun-green" src="/img/icon/theme-sun-green.svg" width="20px" height="20px">
                 </div>
-              </li>
-              <li>
-                <span>{{ gettext("navWrapText") }}</span>
-                <div title="{{ gettext("navWrapTextTitle") }}" class="switch-toggle switch-enabled" id="line-wrap-toggle">
-                  <div class="toggle-backing"></div>
-                  <div class="toggle-button"></div>
-                </div>
-              </li>
-              <li>
-                <span>{{ gettext("navAllowJS") }}</span>
-                <div title="{{ gettext("navAllowJSTitle") }}" class="switch-toggle switch-enabled" id="allow-scripts-toggle">
-                  <div class="toggle-backing"></div>
-                  <div class="toggle-button"></div>
-                </div>
-              </li>
-            </ul>
-          </div>
+              </div>
+            </li>
+            <li>
+              <span>{{ gettext("navWrapText") }}</span>
+              <div title="{{ gettext("navWrapTextTitle") }}" class="switch-toggle switch-enabled" id="line-wrap-toggle">
+                <div class="toggle-backing"></div>
+                <div class="toggle-button"></div>
+              </div>
+            </li>
+            <li>
+              <span>{{ gettext("navAllowJS") }}</span>
+              <div title="{{ gettext("navAllowJSTitle") }}" class="switch-toggle switch-enabled" id="allow-scripts-toggle">
+                <div class="toggle-backing"></div>
+                <div class="toggle-button"></div>
+              </div>
+            </li>
+          </ul>
+        </div>
       </div>
 
     </div>
@@ -109,11 +109,11 @@
         <span title="{{ gettext("navViewTutorialTitle") }}" id="tutorial-title" class="preview-pane-nav-title hide">{{ gettext("navViewTutorial") }}</span>
       </div>
 
-      <div class="refresh-wrapper enabled"  data-adapt-order="2">
+      <div class="refresh-wrapper enabled" data-adapt-order="5" >
         <div title="{{ gettext("navRefreshPreviewIconTitle") }}" id="preview-pane-nav-refresh">
           <img src="/img/icon/refresh.svg">
         </div>
-        <div title="{{ gettext("navToggleAutoUpdateTitle") }}" class="toggle-auto-update">
+        <div data-adapt-order="2" title="{{ gettext("navToggleAutoUpdateTitle") }}" class="toggle-auto-update">
           <span class="checkbox">
             <img class="checkbox-icon" src="/img/icon/checkmark-white.svg"/>
           </span>
@@ -125,7 +125,7 @@
         <div data-adapt-order="3" title="{{ gettext("navDOMElementInspectorIconTitle") }}" id="preview-pane-nav-inspector">
           <div class="icon-wrapper"></div>
         </div>
-        <div class="preview-device-toggle">
+        <div data-adapt-order="4" class="preview-device-toggle">
           <img title="{{ gettext("navDesktopPreviewIconTitle") }}" id="preview-pane-nav-desktop" class="viewmode-active" src="/img/icon/desktop.svg">
           <img title="{{ gettext("navMobilePreviewIconTitle") }}" id="preview-pane-nav-phone" class="viewmode-inactive" src="/img/icon/phone-portrait.svg">
         </div>


### PR DESCRIPTION
This feature makes the UI in each of the header bars (file, editor and preview) adapt to the available amount of space.

It works by measuring the available space and seeing if there is enough room for all of the elements. If there isn't, it looks for elements with an ``adapt-priority`` attribute, and one by one, adds a ``.narrow`` class to them, which changes their styling or hides them entirely.

It looks something like this...

![narrowing](https://cloud.githubusercontent.com/assets/25212/23048176/0f6052d4-f469-11e6-9242-ce452f2f7411.gif)

Fixes #1753 