### PR TITLE
Issue #1755 - Your Projects Page shows Project Descriptions

### DIFF
--- a/public/editor/stylesheets/projects-style.less
+++ b/public/editor/stylesheets/projects-style.less
@@ -4,7 +4,7 @@ body {
 }
 
 #container {
-  width: 65%;
+  width: 80%;
   margin: 35px auto;
   position: relative;
 }
@@ -70,9 +70,23 @@ td.project-title {
   margin-left: 5px;
 }
 
+.project-description {
+  font-size: 0.9em;
+  color: rgba(0,0,0,.5);
+  margin-top: 5px;
+  padding-right: 20px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 60vw;
+  white-space: nowrap;
+}
+
+.project-delete-cell {
+  vertical-align: middle;
+}
 
 .project-delete {
-	float: right;
+  float: right;
   color: black;
   white-space: nowrap;
   padding-right: 8px;

--- a/views/editor/projects.html
+++ b/views/editor/projects.html
@@ -30,9 +30,10 @@
             <a target="_self" href="/{{locale}}/user/{{username}}/{{project.id}}/{{queryString}}"> 
               {{project.title}}
               <span class="project-information"></span>
+              <div class="project-description">{{project.description}}</div>
             </a>
           </td>
-          <td>
+          <td class="project-delete-cell">
             <div class="project-delete" title="{{ gettext("prjListDeleteProjectBtnTitle") }}">
               <div class="icon-garbage-can">
                 <div class="icon-garbage-lid"></div>


### PR DESCRIPTION
![d236e34598d1228269a576fb554b9b7c](https://cloud.githubusercontent.com/assets/14262279/23149476/2b795340-f7ba-11e6-860d-d931e0c08f37.gif)

Let me know if I should change anything. I made sure the "Delete" <td> was centered, otherwise it looked weird positioned below everything, especially in comparison to a project that didn't have a description.