### PR TITLE
Don't leak port 5432 from Vagrant VM into host, part of #1764

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,6 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.network :forwarded_port, host: 3500, guest: 3500 # Thimble
-  config.vm.network :forwarded_port, host: 5432, guest: 5432 # Postgres
   config.vm.network :forwarded_port, host: 2015, guest: 2015 # publish.webmaker.org
   config.vm.network :forwarded_port, host: 8001, guest: 8001 # Published projects
   config.vm.network :forwarded_port, host: 1234, guest: 1234 # id.webmaker.org


### PR DESCRIPTION
This stops us from forwarding the postgres port out of the VM, so that it won't conflict with services running in the host.

I tested it locally, and it still runs fine for me.  I'm not sure if it will fix Pomax's issue.