### PR TITLE
Issue #1262 - Option to disable Auto-Enclosing Tags 

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-menus.js
+++ b/public/editor/scripts/editor/js/fc/bramble-menus.js
@@ -79,6 +79,27 @@ define(function(require) {
       return false;
     });
 
+    //set initial Auto Enclose Tags Toggle UI to correspond to the state it's already in
+    if(bramble.getAutoCloseTags()) {
+      $("#auto-tags-toggle").addClass("switch-enabled");
+    } else {
+      $("#auto-tags-toggle").removeClass("switch-enabled");
+    }
+
+    $("#auto-tags-toggle").click(function() {
+      var $autoTagsToggle = $("#auto-tags-toggle");
+      var toggle = !($autoTagsToggle.hasClass("switch-enabled"));
+
+      if (toggle) {
+        $autoTagsToggle.addClass("switch-enabled");
+        bramble.enableAutoCloseTags();
+      } else {
+        $autoTagsToggle.removeClass("switch-enabled");
+        bramble.disableAutoCloseTags();
+      }
+
+      return false;
+    });
 
     // Theme Toggle
     function lightThemeUI() {

--- a/views/editor/nav-options.html
+++ b/views/editor/nav-options.html
@@ -91,6 +91,13 @@
                   <div class="toggle-button"></div>
                 </div>
               </li>
+              <li>
+                <span>{{ gettext("navAutoEncloseTags") }}</span>
+                <div title="{{ gettext("navAutoEncloseTagsTitle") }}" class="switch-toggle switch-enabled" id="auto-tags-toggle">
+                  <div class="toggle-backing"></div>
+                  <div class="toggle-button"></div>
+                </div>
+              </li>
             </ul>
           </div>
       </div>


### PR DESCRIPTION
In correlation with: https://github.com/mozilla/brackets/pull/601

- Hasn't been localized just yet, this is just for testing the bare minimum if somebody wants to.

NOTE: Why can't I squash the merge commit (there was a conflict, but I solved it on GitHub) into my original commit? Interactive rebase won't show the merge commit...