### PR TITLE
Fix #1747: Project title appears on editor header for anonymous projects

### DIFF
--- a/public/editor/scripts/editor/js/fc/project-rename.js
+++ b/public/editor/scripts/editor/js/fc/project-rename.js
@@ -136,7 +136,7 @@ define(function(require) {
         //  Check whether the project is not anonymous		
         if(context.publisher){
           context.publisher.showUnpublishedChangesPrompt();		
-		}
+        }
       });
     });
   }

--- a/public/editor/scripts/editor/js/fc/project-rename.js
+++ b/public/editor/scripts/editor/js/fc/project-rename.js
@@ -133,10 +133,10 @@ define(function(require) {
         editingComplete(context);
         analytics.event("ProjectRenamed");
 
-        //Check whether the project is not anonymous		
-        if(context.publisher)
+        //  Check whether the project is not anonymous		
+        if(context.publisher){
           context.publisher.showUnpublishedChangesPrompt();		
-
+		}
       });
     });
   }

--- a/public/editor/scripts/editor/js/fc/project-rename.js
+++ b/public/editor/scripts/editor/js/fc/project-rename.js
@@ -133,7 +133,10 @@ define(function(require) {
         editingComplete(context);
         analytics.event("ProjectRenamed");
 
-        context.publisher.showUnpublishedChangesPrompt();
+        //Check whether the project is not anonymous		
+        if(context.publisher)
+          context.publisher.showUnpublishedChangesPrompt();		
+
       });
     });
   }

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -52,7 +52,7 @@ require(["jquery", "bowser"], function($, bowser) {
 
   Bramble.once("error", onError);
 
-  function init(BrambleEditor, Project, SSOOverride) {
+  function init(BrambleEditor, Project, SSOOverride, ProjectRenameUtility) {
     var thimbleScript = document.getElementById("thimble-script");
     var appUrl = thimbleScript.getAttribute("data-app-url");
     var projectDetails = thimbleScript.getAttribute("data-project-details");
@@ -66,6 +66,11 @@ require(["jquery", "bowser"], function($, bowser) {
         console.error("[Bramble] Failed to load Project state, with", err);
       }
 
+      // Initialize the name UI for an anonymous project
+      if(!projectDetails.userID){
+        ProjectRenameUtility.init(appUrl, BrambleEditor.csrfToken);
+      }
+     
       // Initialize the login links
       SSOOverride.init();
 
@@ -76,5 +81,5 @@ require(["jquery", "bowser"], function($, bowser) {
     });
   }
 
-  require(["bramble-editor", "project/project", "sso-override"], init);
+  require(["bramble-editor", "project/project", "sso-override", "fc/project-rename"], init);
 });


### PR DESCRIPTION
I have fixed the issue. Now the title appears for anonymous projects. 
![fix1](https://cloud.githubusercontent.com/assets/13225708/23581585/95e8ea64-00e4-11e7-904f-aad9b1f2b37a.gif)

Let me know, please, if you have any questions or you would like to change something. 
Thank you very much!
