### PR TITLE
Fix: 1637 Always display a Tutorial in Desktop mode 

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -13,6 +13,7 @@ define(function(require) {
 
   var adapting = false;
   var adaptTimeoutMS = 200; // How often we adapt editor bar layout
+  var _isMobileView = false; // to check wheather mobile view is on/off
 
   function updateLayout(data) {
     $(".filetree-pane-nav").width(data.sidebarWidth);
@@ -287,6 +288,12 @@ define(function(require) {
       }
 
       bramble.hideTutorial(setNormalPreview);
+
+      if (_isMobileView)
+      {
+        //if mobile view is preserved
+        activatePreviewMode("mobile");
+      }
     });
     $("#tutorial-title").click(function() {
       if(bramble.getTutorialVisible()) {
@@ -294,6 +301,11 @@ define(function(require) {
       }
 
       bramble.showTutorial(setTutorialPreview);
+      if (_isMobileView)
+      {
+        //display tutorial always in desktop mode
+        activatePreviewMode("destop");
+      }
     });
 
     // Programmatic change to tutorial vs. regular preview mode from Bramble
@@ -309,9 +321,11 @@ define(function(require) {
     // Preview Mode Toggle
     $("#preview-pane-nav-desktop").click(function() {
       activatePreviewMode("desktop");
+      _isMobileView = false; //change state of mobile view mode
     });
     $("#preview-pane-nav-phone").click(function() {
       activatePreviewMode("mobile");
+      _isMobileView = true; //preserve the mobile view mode
     });
 
     function activatePreviewMode(mode) {

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -289,8 +289,7 @@ define(function(require) {
 
       bramble.hideTutorial(setNormalPreview);
 
-      if (_isMobileView)
-      {
+      if (_isMobileView) {
         //if mobile view is preserved
         activatePreviewMode("mobile");
       }
@@ -301,8 +300,8 @@ define(function(require) {
       }
 
       bramble.showTutorial(setTutorialPreview);
-      if (_isMobileView)
-      {
+      
+      if (_isMobileView) {
         //display tutorial always in desktop mode
         activatePreviewMode("destop");
       }

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -13,7 +13,7 @@ define(function(require) {
 
   var adapting = false;
   var adaptTimeoutMS = 200; // How often we adapt editor bar layout
-  var _isMobileView = false; // to check wheather mobile view is on/off
+  var isMobileView = false; // to check whether mobile view is on/off
 
   function updateLayout(data) {
     $(".filetree-pane-nav").width(data.sidebarWidth);
@@ -289,7 +289,7 @@ define(function(require) {
 
       bramble.hideTutorial(setNormalPreview);
 
-      if (_isMobileView) {
+      if (isMobileView) {
         //if mobile view is preserved
         activatePreviewMode("mobile");
       }
@@ -301,7 +301,7 @@ define(function(require) {
 
       bramble.showTutorial(setTutorialPreview);
 
-      if (_isMobileView) {
+      if (isMobileView) {
         //display tutorial always in desktop mode
         activatePreviewMode("desktop");
       }
@@ -320,11 +320,11 @@ define(function(require) {
     // Preview Mode Toggle
     $("#preview-pane-nav-desktop").click(function() {
       activatePreviewMode("desktop");
-      _isMobileView = false; //change state of mobile view mode
+      isMobileView = false; //change state of mobile view mode
     });
     $("#preview-pane-nav-phone").click(function() {
       activatePreviewMode("mobile");
-      _isMobileView = true; //preserve the mobile view mode
+      isMobileView = true; //preserve the mobile view mode
     });
 
     function activatePreviewMode(mode) {

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -300,10 +300,10 @@ define(function(require) {
       }
 
       bramble.showTutorial(setTutorialPreview);
-      
+
       if (_isMobileView) {
         //display tutorial always in desktop mode
-        activatePreviewMode("destop");
+        activatePreviewMode("desktop");
       }
     });
 


### PR DESCRIPTION
Currently, if the preview is set to Mobile view and you click to view the tutorial, it remains in the mobile view. This fix always show the Tutorial file in desktop view. This means that if we're previewing the index.html page in the mobile view, we return the preview to mobile after showing the tutorial.
Fixes : [1637](https://github.com/mozilla/thimble.mozilla.org/issues/1637)