### PR TITLE
Fixed Issue #1397 No longer need to restart server to see new html changes while running thimble on your local machine

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -58,7 +58,7 @@
                 "/vagrant/services/publish.webmaker.org",
                 "/vagrant/client",
                 "/vagrant/public",
-				"/vagrant/views"
+                "/vagrant/views"
             ],
             "watch_options": {
                 "usePolling": true

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -57,6 +57,7 @@
                 "/vagrant/services/id.webmaker.org",
                 "/vagrant/services/publish.webmaker.org",
                 "/vagrant/client",
+				"/vagrant/views",
                 "/vagrant/public"
             ],
             "watch_options": {

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -57,8 +57,8 @@
                 "/vagrant/services/id.webmaker.org",
                 "/vagrant/services/publish.webmaker.org",
                 "/vagrant/client",
-				"/vagrant/views",
-                "/vagrant/public"
+                "/vagrant/public",
+				"/vagrant/views"
             ],
             "watch_options": {
                 "usePolling": true

--- a/server/templatize.js
+++ b/server/templatize.js
@@ -3,7 +3,13 @@
 let Nunjucks = require("nunjucks");
 
 module.exports = function templatize(server, paths) {
-  let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, { noCache: true, watch: true } )), { autoescape: true });
+  let nunjucksOptions = {
+    noCache: true,
+    watch: true,
+    autoescape: true
+};
+
+  let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, nunjucksOptions )));
 
   engine.addFilter("instantiate", function(input) {
     return (new Nunjucks.Template(input)).render(this.getVariables());

--- a/server/templatize.js
+++ b/server/templatize.js
@@ -3,11 +3,11 @@
 let Nunjucks = require("nunjucks");
 
 module.exports = function templatize(server, paths) {
-	 let nunjucksOptions = {
-		noCache: true,
-		watch: true,
-		autoescape: true
-	 };
+let nunjucksOptions = {
+	noCache: true,
+	watch: true,
+	autoescape: true
+};
 
   let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, nunjucksOptions)));
 

--- a/server/templatize.js
+++ b/server/templatize.js
@@ -3,11 +3,11 @@
 let Nunjucks = require("nunjucks");
 
 module.exports = function templatize(server, paths) {
-let nunjucksOptions = {
-	noCache: true,
-	watch: true,
-	autoescape: true
-};
+    let nunjucksOptions = {
+     noCache: true,
+     watch: true,
+     autoescape: true
+    };
 
   let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, nunjucksOptions)));
 

--- a/server/templatize.js
+++ b/server/templatize.js
@@ -3,11 +3,11 @@
 let Nunjucks = require("nunjucks");
 
 module.exports = function templatize(server, paths) {
-	let nunjucksOptions = {
+	 let nunjucksOptions = {
 		noCache: true,
 		watch: true,
 		autoescape: true
-	};
+	 };
 
   let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, nunjucksOptions)));
 

--- a/server/templatize.js
+++ b/server/templatize.js
@@ -3,13 +3,13 @@
 let Nunjucks = require("nunjucks");
 
 module.exports = function templatize(server, paths) {
-  let nunjucksOptions = {
+	let nunjucksOptions = {
     noCache: true,
     watch: true,
     autoescape: true
-};
+	};
 
-  let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, nunjucksOptions )));
+  let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, nunjucksOptions)));
 
   engine.addFilter("instantiate", function(input) {
     return (new Nunjucks.Template(input)).render(this.getVariables());

--- a/server/templatize.js
+++ b/server/templatize.js
@@ -3,7 +3,7 @@
 let Nunjucks = require("nunjucks");
 
 module.exports = function templatize(server, paths) {
-  let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path)), { autoescape: true });
+  let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, { noCache: true, watch: true } )), { autoescape: true });
 
   engine.addFilter("instantiate", function(input) {
     return (new Nunjucks.Template(input)).render(this.getVariables());

--- a/server/templatize.js
+++ b/server/templatize.js
@@ -4,9 +4,9 @@ let Nunjucks = require("nunjucks");
 
 module.exports = function templatize(server, paths) {
 	let nunjucksOptions = {
-    noCache: true,
-    watch: true,
-    autoescape: true
+		noCache: true,
+		watch: true,
+		autoescape: true
 	};
 
   let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, nunjucksOptions)));

--- a/server/templatize.js
+++ b/server/templatize.js
@@ -3,11 +3,11 @@
 let Nunjucks = require("nunjucks");
 
 module.exports = function templatize(server, paths) {
-    let nunjucksOptions = {
-     noCache: true,
-     watch: true,
-     autoescape: true
-    };
+  let nunjucksOptions = {
+    noCache: true,
+    watch: true,
+    autoescape: true
+  };
 
   let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, nunjucksOptions)));
 


### PR DESCRIPTION
With this fix, you now only need to refresh the browser to see new HTML changes while running thimble on your local machine, instead of the old way by restarting your server.

**Old version:**
` let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path)), { autoescape: true });`
**New Version:**
` let engine = new Nunjucks.Environment(paths.map(path => new Nunjucks.FileSystemLoader(path, { noCache: true, watch: true } )), { autoescape: true });`
