### PR TITLE
Remix projects redirect to dead URL on local Thimble setup

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -79,11 +79,11 @@ export OAUTH_AUTHORIZATION_URL="http://localhost:1234"
 export DEFAULT_PROJECT_TITLE="empty-project"
 
 # Location of front-page project resources (see views/homepage/index.html )
-export KEEP_CALM_REMIX_URL="https://thimble-beta.webmaker.org/{{ locale }}/projects/72/remix"
+export KEEP_CALM_REMIX_URL="https://thimble.mozilla.org/{{ locale }}/projects/72/remix"
 export KEEP_CALM_PUBLISHED_URL="https://d157rqmxrxj6ey.cloudfront.net/mozillalearning/171/"
-export BACK_TO_SCHOOL_REMIX_URL="https://thimble-beta.webmaker.org/{{ locale }}/projects/75/remix"
+export BACK_TO_SCHOOL_REMIX_URL="https://thimble.mozilla.org/{{ locale }}/projects/75/remix"
 export BACK_TO_SCHOOL_PUBLISHED_URL="https://d157rqmxrxj6ey.cloudfront.net/mozillalearning/62/"
-export COMIC_STRIP_REMIX_URL="https://thimble-beta.webmaker.org/{{ locale }}/projects/72/remix"
+export COMIC_STRIP_REMIX_URL="https://thimble.mozilla.org/{{ locale }}/projects/72/remix"
 export COMIC_STRIP_PUBLISHED_URL="https://d157rqmxrxj6ey.cloudfront.net/mozillalearning/32/"
 
 export THREE_THINGS_I_HEART_REMIX_URL="https://thimble.mozilla.org/{{ locale }}/projects/2375/remix"


### PR DESCRIPTION
Fixes #1811 