### PR TITLE
Fix #1595: allow blob: URLs in CSP to download zip files from editor iframe

### DIFF
--- a/server/security.js
+++ b/server/security.js
@@ -14,11 +14,13 @@ let defaultCSPDirectives = {
   ],
   frameSrc: [
     "'self'",
-    "https://docs.google.com"
+    "https://docs.google.com",
+    "blob:"
   ],
   childSrc: [
     "'self'",
-    "https://pontoon.mozilla.org"
+    "https://pontoon.mozilla.org",
+    "blob:"
   ],
   frameAncestors: [
     "https://pontoon.mozilla.org"


### PR DESCRIPTION
Tested locally on Firefox, and this allows the `.zip` download to happen.