### PR TITLE
Added extra error message for developer troubleshooting

### DIFF
--- a/locales/en-GB/messages.properties
+++ b/locales/en-GB/messages.properties
@@ -33,7 +33,6 @@ errorLoadingProjectSuggestion=NOTE: if you are using Private Browsing mode, plea
 errorUnsupportedBrowser=Sorry, Thimble won't work in your Browser
 errorUnsupportedBrowserSuggestion=Thimble works in all of the following browsers: <a title="Download Mozilla Firefox" href="https://www.mozilla.org/{{ locale }}/firefox/new/">Firefox</a>, <a title="Download Google Chrome" href="https://www.google.com/chrome/browser/desktop/index.html">Chrome</a>, Internet Explorer 11, Microsoft Edge, Safari (8+), and <a title="Download Opera" href="http://www.opera.com/download">Opera</a>.
 errorUnsupportedBrowserIgnore=Let me try anyway!
-errorLoadingProjectBramble=For error details open your browser's Developer Tools console.
 
 # Userbar
 renameProjectSaveBtn=Save

--- a/locales/en-GB/messages.properties
+++ b/locales/en-GB/messages.properties
@@ -33,6 +33,7 @@ errorLoadingProjectSuggestion=NOTE: if you are using Private Browsing mode, plea
 errorUnsupportedBrowser=Sorry, Thimble won't work in your Browser
 errorUnsupportedBrowserSuggestion=Thimble works in all of the following browsers: <a title="Download Mozilla Firefox" href="https://www.mozilla.org/{{ locale }}/firefox/new/">Firefox</a>, <a title="Download Google Chrome" href="https://www.google.com/chrome/browser/desktop/index.html">Chrome</a>, Internet Explorer 11, Microsoft Edge, Safari (8+), and <a title="Download Opera" href="http://www.opera.com/download">Opera</a>.
 errorUnsupportedBrowserIgnore=Let me try anyway!
+errorLoadingProjectBramble=For error details open your browser's Developer Tools console.
 
 # Userbar
 renameProjectSaveBtn=Save

--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -35,6 +35,7 @@ errorLoadingProjectSuggestion=NOTE: if you are using Private Browsing mode, plea
 errorUnsupportedBrowser=Sorry, Thimble won't work in your Browser
 errorUnsupportedBrowserSuggestion=Thimble works in all of the following browsers: <a title="Download Mozilla Firefox" href="https://www.mozilla.org/{{ locale }}/firefox/new/">Firefox</a>, <a title="Download Google Chrome" href="https://www.google.com/chrome/browser/desktop/index.html">Chrome</a>, Internet Explorer 11, Microsoft Edge, Safari (8+), and <a title="Download Opera" href="http://www.opera.com/download">Opera</a>.
 errorUnsupportedBrowserIgnore=Let me try anyway!
+errorLoadingProjectBramble=For error details open your browser's Developer Tools console.
 
 # Userbar
 renameProjectSaveBtn=Save

--- a/views/editor/bramble.html
+++ b/views/editor/bramble.html
@@ -120,6 +120,7 @@
         <div class="loading-message message">{{ gettext("loadingProject") }}</div>
         <div class="error-message message">
             <p>{{ gettext("errorLoadingProject") | safe }}</p>
+            <p>{{ gettext("errorLoadingProjectBramble") }}</p>
             <p>{{ gettext("errorLoadingProjectSuggestion") }}</p>
         </div>
     </div>


### PR DESCRIPTION
Added errorLoadingProjectBramble error message to messages.properties
Added errorLoadingProjectBramble error to bramble.html

I saw that the error message already existed and showed in developers tools console.
I added a error message that tells the user to look in their browsers developer tools console to see error details.  
This will make is so that developers know if bramble is the cause of the error right away alongside of any other errors they might not have known about. 
Here is a picture of the dev tool error message.
https://gyazo.com/e1a4ffbbe37a11aaf8200c8273327a77

fixes #1758 