### PR TITLE
Fix Issue#1778: Create a default index.html file if there isn't one when the browser refreshes

### DIFF
--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -239,37 +239,23 @@ define(function(require) {
           }
 
           // Find the index.html file in the project root to open
-          _fs.readdir(getRoot(), function(err, found) {
-            if(err) {
-              return callback(err);
-            }
-
-            // Try to grab the index.html
-            var indexPos = 0;
-            var foundIndexHTML = false;
-            found.forEach(function(path, idx) {
-              if(Path.basename(path) === "index.html") {
-                indexPos = idx;
-                foundIndexHTML = true;
-              }
-            });
-
-            if (foundIndexHTML) {
-              callback(null, found[indexPos]);
-            }
-
-            // Create a default index.html file
-            if (!foundIndexHTML) {
+          var indexLocation = Path.join(getRoot(),"index.html")
+          _fs.exists(indexLocation, function(exist) {
+            if(exist) {
+              callback(null,indexLocation)
+              return;
+            } else {
+              // Create a default index.html file
               var location = "/default-files/html.txt";
               $.get(location).then(function(data) {
-                var file = getRoot() + "/index.html";
-                _fs.writeFile(file, data, function(err) {
+                _fs.writeFile(indexLocation, data, function(err) {
                   if (err) {
                     console.error("Cannot write file to project: " + err);
                     callback(err);
                     return;
                   }
-                  callback(null, file);
+                  callback(null, indexLocation);
+                  return;
                 });
               }, function(err) {
                 if (err) {

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -255,6 +255,10 @@ define(function(require) {
               }
             });
 
+            if (foundIndexHTML) {
+              callback(null, found[indexPos]);
+            }
+
             // Create a default index.html file
             if (!foundIndexHTML) {
               var location = "/default-files/html.txt";
@@ -262,8 +266,11 @@ define(function(require) {
                 var file = getRoot() + "/index.html";
                 _fs.writeFile(file, data, function(err) {
                   if (err) {
-                    return console.error("Cannot write file to project: " + err);
+                    console.error("Cannot write file to project: " + err);
+                    callback(err);
+                    return;
                   }
+                  callback(null, file);
                 });
               }, function(err) {
                 if (err) {
@@ -274,7 +281,6 @@ define(function(require) {
                 callback();
               });
             }
-            callback(null, found[indexPos]);
           });
         });
       });

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -239,10 +239,10 @@ define(function(require) {
           }
 
           // Find the index.html file in the project root to open
-          var indexLocation = Path.join(getRoot(),"index.html")
+          var indexLocation = Path.join(getRoot(),"index.html");
           _fs.exists(indexLocation, function(exist) {
             if(exist) {
-              callback(null,indexLocation)
+              callback(null,indexLocation);
               return;
             } else {
               // Create a default index.html file

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -263,16 +263,11 @@ define(function(require) {
               };
               var location = "/default-files/html.txt";
               $.get(location).then(function(data) {
-                fileOptions.contents = data;
-                Bramble.once("ready", function(bramble) {
-                  bramble.addNewFile(fileOptions, function(err) {
-                    if (err) {
-                      console.error("[Bramble] Failed to write new file", err);
-                      callback(err);
-                      return;
-                    }
-                    callback();
-                  });
+                var file = getRoot() + "/index.html";
+                _fs.writeFile(file, data, function(err) {
+                  if (err) {
+                    return console.error("Cannot write file to project: " + err);
+                  }
                 });
               }, function(err) {
                 if (err) {

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -264,7 +264,6 @@ define(function(require) {
                   if (err) {
                     return console.error("Cannot write file to project: " + err);
                   }
-                  callback();
                 });
               }, function(err) {
                 if (err) {

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -239,33 +239,32 @@ define(function(require) {
           }
 
           // Find the index.html file in the project root to open
-          var indexLocation = Path.join(getRoot(),"index.html");
-          _fs.exists(indexLocation, function(exist) {
-            if(exist) {
-              callback(null,indexLocation);
+          var indexLocation = Path.join(getRoot(), "index.html");
+          _fs.exists(indexLocation, function(exists) {
+            if(exists) {
+              callback(null, indexLocation);
               return;
-            } else {
-              // Create a default index.html file
-              var location = "/default-files/html.txt";
-              $.get(location).then(function(data) {
-                _fs.writeFile(indexLocation, data, function(err) {
-                  if (err) {
-                    console.error("Cannot write file to project: " + err);
-                    callback(err);
-                    return;
-                  }
-                  callback(null, indexLocation);
-                  return;
-                });
-              }, function(err) {
+            }
+            // Create a default index.html file
+            var location = "/default-files/html.txt";
+            $.get(location).then(function(data) {
+              _fs.writeFile(indexLocation, data, function(err) {
                 if (err) {
-                  console.error("Failed to download " + location, err);
+                  console.error("Cannot write file to project: " + err);
                   callback(err);
                   return;
                 }
-                callback();
+                callback(null, indexLocation);
+                return;
               });
-            }
+            }, function(err) {
+              if (err) {
+                console.error("Failed to download " + location, err);
+                callback(err);
+                return;
+              }
+              callback();
+            });
           });
         });
       });

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -259,7 +259,6 @@ define(function(require) {
               });
             }, function(err) {
               if (err) {
-                console.error("Failed to download " + DEFAULT_INDEX_HTML_URL, err);
                 callback(err);
                 return;
               }

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -18,6 +18,8 @@ define(function(require) {
   var _remixId;
   var _description;
 
+  var DEFAULT_INDEX_HTML_URL = "/default-files/html.txt";
+
   function getAnonymousId() {
     return _anonymousId;
   }
@@ -246,8 +248,7 @@ define(function(require) {
               return;
             }
             // Create a default index.html file
-            var location = "/default-files/html.txt";
-            $.get(location).then(function(data) {
+            $.get(DEFAULT_INDEX_HTML_URL).then(function(data) {
               _fs.writeFile(indexLocation, data, function(err) {
                 if (err) {
                   console.error("Cannot write file to project: " + err);
@@ -255,11 +256,10 @@ define(function(require) {
                   return;
                 }
                 callback(null, indexLocation);
-                return;
               });
             }, function(err) {
               if (err) {
-                console.error("Failed to download " + location, err);
+                console.error("Failed to download " + DEFAULT_INDEX_HTML_URL, err);
                 callback(err);
                 return;
               }

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -257,13 +257,7 @@ define(function(require) {
                 }
                 callback(null, indexLocation);
               });
-            }, function(err) {
-              if (err) {
-                callback(err);
-                return;
-              }
-              callback();
-            });
+            }, callback);
           });
         });
       });

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -264,6 +264,7 @@ define(function(require) {
                   if (err) {
                     return console.error("Cannot write file to project: " + err);
                   }
+                  callback();
                 });
               }, function(err) {
                 if (err) {

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -1,4 +1,5 @@
 define(function(require) {
+  var $ = require("jquery");
   var Constants = require("constants");
   var Remote = require("project/remote");
   var Metadata = require("project/metadata");
@@ -246,12 +247,42 @@ define(function(require) {
 
             // Look for an HTML file to open, ideally index.html
             var indexPos = 0;
+            var foundIndexHTML = false;
             found.forEach(function(path, idx) {
               if(Path.basename(path) === "index.html") {
                 indexPos = idx;
+                foundIndexHTML = true;
               }
             });
 
+            // Create a default index.html file
+            if (!foundIndexHTML) {
+              var fileOptions = {
+                basenamePrefix: "index",
+                ext: ".html"
+              };
+              var location = "/default-files/html.txt";
+              $.get(location).then(function(data) {
+                fileOptions.contents = data;
+                Bramble.once("ready", function(bramble) {
+                  bramble.addNewFile(fileOptions, function(err) {
+                    if (err) {
+                      console.error("[Bramble] Failed to write new file", err);
+                      callback(err);
+                      return;
+                    }
+                    callback();
+                  });
+                });
+              }, function(err) {
+                if (err) {
+                  console.error("Failed to download " + location, err);
+                  callback(err);
+                  return;
+                }
+                callback();
+              });
+            }
             callback(null, found[indexPos]);
           });
         });

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -257,10 +257,6 @@ define(function(require) {
 
             // Create a default index.html file
             if (!foundIndexHTML) {
-              var fileOptions = {
-                basenamePrefix: "index",
-                ext: ".html"
-              };
               var location = "/default-files/html.txt";
               $.get(location).then(function(data) {
                 var file = getRoot() + "/index.html";

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -238,14 +238,13 @@ define(function(require) {
             return callback(err);
           }
 
-          // Find an HTML file to open in the project, hopefully /index.html
-          var sh = new _fs.Shell();
-          sh.find(getRoot(), {name: "*.html"}, function(err, found) {
+          // Find the index.html file in the project root to open
+          _fs.readdir(getRoot(), function(err, found) {
             if(err) {
               return callback(err);
             }
 
-            // Look for an HTML file to open, ideally index.html
+            // Try to grab the index.html
             var indexPos = 0;
             var foundIndexHTML = false;
             found.forEach(function(path, idx) {


### PR DESCRIPTION
I tried to "ask" Bramble to create the index.html file once it's ready. For this fix, the following message will still shows up when there was no index.html file previously:

![image](https://cloud.githubusercontent.com/assets/10606265/23622671/8ddc6f00-026d-11e7-8335-e015ea892f2a.png)

I also have a different fix that looks something like this:
````
var file = getRoot() + "/index.html";
fs.writeFile(file, data, function(err) {
  if (err) {
    return console.error("Cannot write file to project: " + err);
  }
});
````
This is obviously simpler and probably won't produce the above message. However, I'm not sure why I cannot declare `var fs = require("fs");` in [this file](https://github.com/mozilla/thimble.mozilla.org/blob/master/public/editor/scripts/project/project.js#L2). This is the error message on the browser console:
````
GET http://localhost:3500/en-US/en_US/editor/scripts/editor/js/fs.js 404 (Not Found)
Uncaught Error: Script error
http://requirejs.org/docs/errors.html#scripterror
    at H (require.min.js:9)
    at HTMLScriptElement.onScriptError (require.min.js:32)
````
I am wondering if this is due to the project structure of Thimble or if I am missing something?
