### PR TITLE
Updates style.less to remove top margin from icons

### DIFF
--- a/public/homepage/stylesheets/style.less
+++ b/public/homepage/stylesheets/style.less
@@ -153,12 +153,10 @@ footer {
 
     .terms .icon {
       background-image: ~"url(/img/footer-icon-terms.svg)";
-      top: -5px;
     }
 
     .privacy .icon {
       background-image: ~"url(/img/footer-icon-privacy.svg)";
-      top: -5px;
     }
   }
 


### PR DESCRIPTION
Turns out there was a margin of 5 px left in the the css file.
This was making the terms and privacy icon slide up slightly.
Not sure if it was left as an ester egg?
Fixes issue #1827