### PR TITLE
Fix #1829: Added warning supression for new versions of jshint

### DIFF
--- a/server/lib/environment.js
+++ b/server/lib/environment.js
@@ -1,3 +1,5 @@
+/*jshint newcap:false */
+
 var habitat = require('habitat');
 habitat.load(require('path').resolve(__dirname, '../../.env'));
 var env = new habitat();

--- a/server/lib/environment.js
+++ b/server/lib/environment.js
@@ -1,5 +1,4 @@
-/*jshint newcap:false */
-
+/* jshint newcap:false */
 var habitat = require('habitat');
 habitat.load(require('path').resolve(__dirname, '../../.env'));
 var env = new habitat();


### PR DESCRIPTION
Here is the fix of the issue that happens with [deps update](https://github.com/mozilla/thimble.mozilla.org/pull/1828). 
This request updates deps, and the newest version of jshint, treats this code as an error, instead of just as a warning. 
```js
var habitat = require('habitat');
habitat.load(require('path').resolve(__dirname, '../../.env'));
var env = new habitat();
```
There is anything wrong with this code. That's why the easist solution to pass new updates of jhint, is to supress the warning. In addition, this syntax check will be deprecated in the next version of jshint.  