### PR TITLE
Makes sure the adapt method gets called after resizing

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -13,16 +13,22 @@ define(function(require) {
 
   var adapting = false;
   var adaptTimeoutMS = 200; // How often we adapt editor bar layout
+  var adaptTimeout;
 
   function updateLayout(data) {
     $(".filetree-pane-nav").width(data.sidebarWidth);
     $(".editor-pane-nav").width(data.firstPaneWidth);
     $(".preview-pane-nav").width(data.secondPaneWidth);
 
-    // Only adapt the layout every once in a while
+    window.clearTimeout(adaptTimeout);
+    adaptTimeout = setTimeout(function(){
+      adaptLayout();
+    },adaptTimeoutMS);
+
     if(!adapting) {
       adapting = true;
       adaptLayout();
+      window.clearTimeout(adaptTimeout);
       setTimeout(function(){
         adapting = false;
       },adaptTimeoutMS);


### PR DESCRIPTION
The old implementation waits 200ms after adapting the layout before it calls the adapt method again. A lot can happen in that 200ms, so we want to also make sure we call it once after the last UI resize.

This feels a bit janky @Pomax so I'm curious about your thoughts.

The goal is to call the adapt method frequently, but not more often than 200ms, while also calling it one last time at the end.

To test this, resize the windows quickly - the icons should always adapt.