### PR TITLE
Deleted L-15 to L-19 as frame src has been deprecated.

### DIFF
--- a/server/security.js
+++ b/server/security.js
@@ -12,11 +12,7 @@ let defaultCSPDirectives = {
     "https://pontoon.mozilla.org",
     "https://mozilla.github.io/thimble-homepage-gallery/activities.json"
   ],
-  frameSrc: [
-    "'self'",
-    "https://docs.google.com",
-    "blob:"
-  ],
+
   childSrc: [
     "'self'",
     "https://pontoon.mozilla.org",


### PR DESCRIPTION
Updated CSP definations , as directive ‘frame-src’ has been disapproved , we are using directive ‘child-src’ instead. 
As far as I am able to understand that browsers we support don't need it by referring to mozilla and microsoft developer CSP documentations . 