### PR TITLE
Fix ENOSPC errors watching node_modules, don't pass node_modules to nunjucks

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -41,7 +41,7 @@ server.locals.node_path = "node_modules";
 /**
  * Templating engine
  */
-templatize(server, [ "views", "node_modules" ]);
+templatize(server, [ "views" ]);
 
 
 /**


### PR DESCRIPTION
In https://github.com/mozilla/thimble.mozilla.org/commit/20fa70c77fb6a9dbdad29492989715178954fada we started using `node_modules` vs. front-end resources installed via bowser.  Then, in https://github.com/mozilla/thimble.mozilla.org/pull/1808 we started having nunjucks watch for template changes in the directories it used.  The combination of these two things meant that we started watching `node_modules` which causes the Vagrant VM to run out of space as it tries to watch all the files under `node_modules/*`.  On my machine Thimble takes forever to start, and then I get errors like this:

```
4|thimble  | Watcher error: Error: watch node_modules/grunt-lesslint/node_modules/less/test/less/errors/property-in-root.txt ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/nunjucks/node_modules/yargs/node_modules/window-size/cli.js ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/grunt-lesslint/node_modules/less/test/less/errors/property-ie5-hack.txt ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/nunjucks/node_modules/yargs/node_modules/window-size/index.js ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/grunt-lesslint/node_modules/less/test/less/errors/property-in-root.less ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/nunjucks/node_modules/yargs/node_modules/window-size/package.json ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/grunt-lesslint/node_modules/less/test/less/errors/property-in-root3.txt ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/nunjucks/node_modules/yargs/node_modules/os-locale/node_modules ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/grunt-lesslint/node_modules/less/test/less/errors/property-in-root2.less ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/nunjucks/node_modules/yargs/node_modules/os-locale/index.js ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/grunt-lesslint/node_modules/less/test/less/errors/property-in-root3.less ENOSPC
4|thimble  | Watcher error: Error: watch node_modules/nunjucks/node_modules/yargs/node_modules/os-locale/license ENOSPC
```

And so on forever.  The `ENOSPC` is a clue.

This PR fixes things so we don't watch `node_modules` at all.  cc @lkisac, @JohnEJames who might be interested in this.