### PR TITLE
Update to Google Analytics

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function( grunt ) {
             "PathCache": "editor/scripts/path-cache",
             "constants": "editor/scripts/constants",
             "EventEmitter": "../node_modules/wolfy87-eventemitter/EventEmitter.min",
-            "analytics": "../node_modules/webmaker-analytics/analytics",
+            "analytics": "editor/scrips/analytics",
             "moment": "../node_modules/moment/min/moment-with-locales.min",
             "gallery": "homepage/scripts/gallery"
           },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function( grunt ) {
             "PathCache": "editor/scripts/path-cache",
             "constants": "editor/scripts/constants",
             "EventEmitter": "../node_modules/wolfy87-eventemitter/EventEmitter.min",
-            "analytics": "editor/scrips/analytics",
+            "analytics": "editor/scripts/analytics",
             "moment": "../node_modules/moment/min/moment-with-locales.min",
             "gallery": "homepage/scripts/gallery"
           },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "throng": "^4.0.0",
     "time-grunt": "^1.4.0",
     "uuid": "2.0.3",
-    "webmaker-analytics": "~0.1.7",
     "webmaker-i18n": "^0.3.31",
     "wolfy87-eventemitter": "~4.3.0"
   },

--- a/public/editor/scripts/analytics.js
+++ b/public/editor/scripts/analytics.js
@@ -1,3 +1,6 @@
+// Based on https://github.com/mozilla/webmaker-analytics
+// Licensed under the MPL 2.0 License: https://github.com/mozilla/webmaker-analytics/blob/master/LICENSE
+
 (function(global, factory) {
   if (typeof define === 'function' && define.amd) {
     define(factory);
@@ -87,7 +90,7 @@
       } else {
         if(mightBeEmail(options.label)) {
           warn("`label` arg looks like an email address, redacting.");
-          label = _redacted;
+          options.label = _redacted;
         }
         eventOptions.label = trim(options.label);
       }

--- a/public/editor/scripts/analytics.js
+++ b/public/editor/scripts/analytics.js
@@ -1,5 +1,6 @@
 // Based on https://github.com/mozilla/webmaker-analytics
 // Licensed under the MPL 2.0 License: https://github.com/mozilla/webmaker-analytics/blob/master/LICENSE
+/* global ga */
 
 (function(global, factory) {
   if (typeof define === 'function' && define.amd) {

--- a/public/editor/scripts/analytics.js
+++ b/public/editor/scripts/analytics.js
@@ -144,7 +144,7 @@
       }
 
       ga('send', fieldObject);
-    };
+    }
   }
 
   // Use a consistent prefix and check if arg starts with a forward slash

--- a/public/editor/scripts/analytics.js
+++ b/public/editor/scripts/analytics.js
@@ -1,0 +1,188 @@
+(function(global, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(factory);
+  }
+  else if (typeof module === "object" && module && typeof module.exports === "object") {
+    module.exports = factory();
+  } else {
+    global.analytics = factory();
+  }
+}(this, function() {
+
+  // Make sure _gaq is on the global so we don't die trying to access it
+  if(!this._gaq) {
+    this._gaq = [];
+  }
+
+  var _redacted = "REDACTED (Potential Email Address)";
+
+  /**
+   * To Title Case 2.1 - http://individed.com/code/to-title-case/
+   * Copyright 2008-2013 David Gouch. Licensed under the MIT License.
+   * https://github.com/gouch/to-title-case
+   */
+  function toTitleCase(s){
+    var smallWords = /^(a|an|and|as|at|but|by|en|for|if|in|nor|of|on|or|per|the|to|vs?\.?|via)$/i;
+    s = trim(s);
+
+    return s.replace(/[A-Za-z0-9\u00C0-\u00FF]+[^\s-]*/g, function(match, index, title){
+      if (index > 0 &&
+          index + match.length !== title.length &&
+          match.search(smallWords) > -1 &&
+          title.charAt(index - 2) !== ":" &&
+          (title.charAt(index + match.length) !== '-' || title.charAt(index - 1) === '-') &&
+          title.charAt(index - 1).search(/[^\s-]/) < 0) {
+        return match.toLowerCase();
+      }
+
+      if (match.substr(1).search(/[A-Z]|\../) > -1) {
+        return match;
+      }
+
+      return match.charAt(0).toUpperCase() + match.substr(1);
+    });
+  }
+
+  // GA strings need to have leading/trailing whitespace trimmed, and not all
+  // browsers have String.prototoype.trim().
+  function trim(s) {
+    return s.replace(/^\s+|\s+$/g, '');
+  }
+
+  // See if s could be an email address. We don't want to send personal data like email.
+  function mightBeEmail(s) {
+    // There's no point trying to validate rfc822 fully, just look for ...@...
+    return (/[^@]+@[^@]+/).test(s);
+  }
+
+  function warn(msg) {
+    console.warn("[analytics] " + msg);
+  }
+
+  // This receives the event action, then passes it on to sendEvent to send out
+  function event(options) {
+    options = options || {};
+
+    var eventOptions = {};
+
+    // Event Category
+    eventOptions.category = options.category || "Uncategorized";
+
+    // Event Action
+    if(!options.action) {
+      warn("Expected `action` arg.");
+      return;
+    }
+    if(mightBeEmail(options.action)) {
+      warn("`action` arg looks like an email address, redacting.");
+      options.action = _redacted;
+    }
+    eventOptions.action = toTitleCase(options.action);
+
+    // Event Label
+    if(options.label) {
+      if(typeof options.label !== "string") {
+        warn("Expected `label` arg to be a String.");
+      } else {
+        if(mightBeEmail(options.label)) {
+          warn("`label` arg looks like an email address, redacting.");
+          label = _redacted;
+        }
+        eventOptions.label = trim(options.label);
+      }
+    }
+
+    // Event Value
+    if(options.value || options.value === 0) {
+      if(typeof value !== "number") {
+        warn("Expected `value` arg to be a Number.");
+      } else {
+        // Force value to int
+        eventOptions.value = options.value|0;
+      }
+    }
+
+    // noninteraction: An optional boolean that when set to true, indicates that
+    // the event hit will not be used in bounce-rate calculation.
+    if(options.nonInteraction) {
+      if(typeof options.nonInteraction !== "boolean") {
+        warn("Expected `noninteraction` arg to be a Boolean.");
+      } else {
+        eventOptions.nonInteraction = options.nonInteraction === true;
+      }
+    }
+
+    sendEvent(eventOptions);
+  }
+
+  function sendEvent(options) {
+
+    if(typeof ga === "function") {
+      // Transform the argument array to match the expected call signature for ga(), see:
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/events#overview
+
+      // Required Event Field
+      var fieldObject = {
+        'hitType': 'event',
+        'eventCategory': options.category,
+        'eventAction': options.action
+      };
+
+      // Optional Event Fields
+      if(options.label) {
+        fieldObject['eventLabel'] = options.label;
+      }
+      if(options.label || options.label === 0) {
+        fieldObject['eventValue'] = options.value;
+      }
+      if(options.nonInteraction === true) {
+        fieldObject['nonInteraction'] = 1;
+      }
+
+      ga('send', fieldObject);
+    };
+  }
+
+  // Use a consistent prefix and check if arg starts with a forward slash
+  function prefixVirtualPageview(s) {
+    // Bail if s is already prefixed.
+    if(/^\/virtual\//.test(s)) {
+      return s;
+    }
+    // Make sure s has a leading / then add prefix and return
+    s = s.replace(/^[/]?/, '/');
+    return '/virtual' + s;
+  }
+
+  function virtualPageview(virtualPagePath) {
+    if(!virtualPagePath) {
+      warn("Expected `virtualPagePath` arg.");
+      return;
+    }
+    virtualPagePath = trim(virtualPagePath);
+
+    var eventOptions = {};
+    eventOptions.virtualPagePath = prefixVirtualPageview(virtualPagePath);
+
+    sendVirtualPageView(eventOptions);
+  }
+
+  function sendVirtualPageView(options) {
+    if(typeof ga === "function") {
+      // Transform the argument array to match the expected call signature for ga():
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference
+      var fieldObject = {
+        'hitType': 'pageview',
+        'page': options.virtualPagePath
+      };
+      ga('send', fieldObject);
+    }
+  }
+
+
+  return {
+    event: event,
+    virtualPageview: virtualPageview
+  };
+
+}));

--- a/public/editor/scripts/analytics.js
+++ b/public/editor/scripts/analytics.js
@@ -9,10 +9,11 @@
   }
 }(this, function() {
 
-  // Make sure _gaq is on the global so we don't die trying to access it
-  if(!this._gaq) {
-    this._gaq = [];
-  }
+  // Strings for event category names
+  var eventCategories = {};
+  eventCategories.EDITOR_UI = "Editor UI";
+  eventCategories.HOMEPAGE = "Homepage";
+  eventCategories.PROJECT_ACTIONS = "Project Actions";
 
   var _redacted = "REDACTED (Potential Email Address)";
 
@@ -182,6 +183,7 @@
 
   return {
     event: event,
+    eventCategories: eventCategories,
     virtualPageview: virtualPageview
   };
 

--- a/public/editor/scripts/editor/js/fc/bramble-menus.js
+++ b/public/editor/scripts/editor/js/fc/bramble-menus.js
@@ -20,14 +20,14 @@ define(function(require) {
     $("#editor-pane-nav-decrease-font").click(function() {
       bramble.decreaseFontSize(function() {
         var fontSize = bramble.getFontSize();
-        analytics.event({ category : "Editor UI", action : "Font Size Changed", label : "Decreased to " + fontSize });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Font Size Changed", label : "Decreased to " + fontSize });
       });
     });
 
     $("#editor-pane-nav-increase-font").click(function() {
       bramble.increaseFontSize(function() {
         var fontSize = bramble.getFontSize();
-        analytics.event({ category : "Editor UI", action : "Font Size Changed", label : "Increased to " + fontSize });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Font Size Changed", label : "Increased to " + fontSize });
       });
     });
 
@@ -50,7 +50,7 @@ define(function(require) {
       // Toggle current value
       setWordWrap(!bramble.getWordWrap());
       var mode = !bramble.getWordWrap() ? "Enabled" : "Disabled";
-      analytics.event({ category : "Editor UI", action : "Word Wrap Toggle", label : mode });
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Word Wrap Toggle", label : mode });
       return false;
     });
     // Set initial UI value to match editor value
@@ -70,11 +70,11 @@ define(function(require) {
       if(toggle) {
         $allowScriptsToggle.addClass("switch-enabled");
         bramble.enableJavaScript();
-        analytics.event({ category : "Editor UI", action : "Toggle JavaScript", label : "Enabled" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Toggle JavaScript", label : "Enabled" });
       } else {
         $allowScriptsToggle.removeClass("switch-enabled");
         bramble.disableJavaScript();
-        analytics.event({ category : "Editor UI", action : "Toggle JavaScript", label : "Disabled" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Toggle JavaScript", label : "Disabled" });
       }
 
       return false;
@@ -144,10 +144,10 @@ define(function(require) {
     function toggleTheme() {
       if(bramble.getTheme() === "dark-theme") {
         setTheme("light-theme");
-        analytics.event({ category : "Editor UI", action : "Theme Changed", label : "Light Theme" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Theme Changed", label : "Light Theme" });
       } else {
         setTheme("dark-theme");
-        analytics.event({ category : "Editor UI", action : "Theme Changed", label : "Dark Theme" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Theme Changed", label : "Dark Theme" });
       }
     }
     $("#theme-light").click(toggleTheme);
@@ -207,7 +207,7 @@ define(function(require) {
         if (err) {
           console.log("[Brackets] Failed to insert default HTML file", err);
         }
-        analytics.event({ category : "Editor UI", action : "Add File", label : "HTML" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Add File", label : "HTML" });
       });
     });
     $addCss.click(function() {
@@ -219,7 +219,7 @@ define(function(require) {
         if (err) {
           console.log("[Brackets] Failed to insert default CSS file", err);
         }
-        analytics.event({ category : "Editor UI", action : "Add File", label : "CSS" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Add File", label : "CSS" });
       });
     });
     $addJs.click(function() {
@@ -231,7 +231,7 @@ define(function(require) {
         if (err) {
           console.log("[Brackets] Failed to insert default JS file", err);
         }
-        analytics.event({ category : "Editor UI", action : "Add File", label : "JS" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Add File", label : "JS" });
       });
     });
     $addTutorial.click(function() {
@@ -239,14 +239,14 @@ define(function(require) {
         if (err) {
           console.log("[Brackets] Failed to insert tutorial.html", err);
         }
-        analytics.event({ category : "Editor UI", action : "Add File", label : "Tutorial" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Add File", label : "Tutorial" });
       });
     });
 
     $addUpload.click(function() {
       menu.close();
       bramble.showUploadFilesDialog();
-      analytics.event({ category : "Editor UI", action : "Upload File Dialog Shown"});
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Upload File Dialog Shown"});
     });
 
     // We hide the add tutorial button if a tutorial exists

--- a/public/editor/scripts/editor/js/fc/bramble-menus.js
+++ b/public/editor/scripts/editor/js/fc/bramble-menus.js
@@ -20,14 +20,14 @@ define(function(require) {
     $("#editor-pane-nav-decrease-font").click(function() {
       bramble.decreaseFontSize(function() {
         var fontSize = bramble.getFontSize();
-        analytics.event("DecreaseFontSize", {label: "Decreased font size to " + fontSize});
+        analytics.event({ category : "Editor UI", action : "Font Size Changed", label : "Decreased to " + fontSize });
       });
     });
 
     $("#editor-pane-nav-increase-font").click(function() {
       bramble.increaseFontSize(function() {
         var fontSize = bramble.getFontSize();
-        analytics.event("IncreaseFontSize", {label: "Increased font size to " + fontSize});
+        analytics.event({ category : "Editor UI", action : "Font Size Changed", label : "Increased to " + fontSize });
       });
     });
 
@@ -44,12 +44,13 @@ define(function(require) {
       var method = value ? "enableWordWrap" : "disableWordWrap";
       bramble[method](function() {
         setWordWrapUI(value);
-        analytics.event(method);
       });
     }
     $("#line-wrap-toggle").click(function() {
       // Toggle current value
       setWordWrap(!bramble.getWordWrap());
+      var mode = !bramble.getWordWrap() ? "Enabled" : "Disabled";
+      analytics.event({ category : "Editor UI", action : "Word Wrap Toggle", label : mode });
       return false;
     });
     // Set initial UI value to match editor value
@@ -69,11 +70,11 @@ define(function(require) {
       if(toggle) {
         $allowScriptsToggle.addClass("switch-enabled");
         bramble.enableJavaScript();
-        analytics.event("EnableJavaScript");
+        analytics.event({ category : "Editor UI", action : "Toggle JavaScript", label : "Enabled" });
       } else {
         $allowScriptsToggle.removeClass("switch-enabled");
         bramble.disableJavaScript();
-        analytics.event("DisableJavaScript");
+        analytics.event({ category : "Editor UI", action : "Toggle JavaScript", label : "Disabled" });
       }
 
       return false;
@@ -134,18 +135,19 @@ define(function(require) {
       if(theme === "light-theme") {
         bramble.useLightTheme();
         lightThemeUI();
-        analytics.event("LightTheme");
       } else if(theme === "dark-theme") {
         bramble.useDarkTheme();
         darkThemeUI();
-        analytics.event("DarkTheme");
+
       }
     }
     function toggleTheme() {
       if(bramble.getTheme() === "dark-theme") {
         setTheme("light-theme");
+        analytics.event({ category : "Editor UI", action : "Theme Changed", label : "Light Theme" });
       } else {
         setTheme("dark-theme");
+        analytics.event({ category : "Editor UI", action : "Theme Changed", label : "Dark Theme" });
       }
     }
     $("#theme-light").click(toggleTheme);
@@ -205,7 +207,7 @@ define(function(require) {
         if (err) {
           console.log("[Brackets] Failed to insert default HTML file", err);
         }
-        analytics.event("AddHTMLFile");
+        analytics.event({ category : "Editor UI", action : "Add File", label : "HTML" });
       });
     });
     $addCss.click(function() {
@@ -217,7 +219,7 @@ define(function(require) {
         if (err) {
           console.log("[Brackets] Failed to insert default CSS file", err);
         }
-        analytics.event("AddCSSFile");
+        analytics.event({ category : "Editor UI", action : "Add File", label : "CSS" });
       });
     });
     $addJs.click(function() {
@@ -229,7 +231,7 @@ define(function(require) {
         if (err) {
           console.log("[Brackets] Failed to insert default JS file", err);
         }
-        analytics.event("AddJSFile");
+        analytics.event({ category : "Editor UI", action : "Add File", label : "JS" });
       });
     });
     $addTutorial.click(function() {
@@ -237,14 +239,14 @@ define(function(require) {
         if (err) {
           console.log("[Brackets] Failed to insert tutorial.html", err);
         }
-        analytics.event('AddTutorial');
+        analytics.event({ category : "Editor UI", action : "Add File", label : "Tutorial" });
       });
     });
 
     $addUpload.click(function() {
       menu.close();
       bramble.showUploadFilesDialog();
-      analytics.event("ShowUploadFilesDialog");
+      analytics.event({ category : "Editor UI", action : "Upload File Dialog Shown"});
     });
 
     // We hide the add tutorial button if a tutorial exists

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -115,7 +115,7 @@ define(function(require) {
       e.preventDefault();
       e.stopPropagation();
 
-      analytics.event({ category : "Project Actions", action : "New Project", label : "New authenticated project" });
+      analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "New Project", label : "New authenticated project" });
 
       var queryString = window.location.search;
       var cacheBust = "cacheBust=" + Date.now();
@@ -131,7 +131,7 @@ define(function(require) {
       }
 
       // Add label that it happened in the menu?
-      analytics.event({ category : "Project Actions", action : "Delete Project"});
+      analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "Delete Project"});
 
       var request = $.ajax({
         headers: {
@@ -155,7 +155,7 @@ define(function(require) {
 
     $("#filetree-pane-nav-export-project-zip").click(function() {
       bramble.export();
-      analytics.event({ category : "Project Actions", action : "Export ZIP"});
+      analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "Export ZIP"});
       return false;
     });
 
@@ -180,13 +180,13 @@ define(function(require) {
     // Undo
     $("#editor-pane-nav-undo").click(function() {
       bramble.undo();
-      analytics.event({ category : "Editor UI", action : "Undo" });
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Undo" });
     });
 
     // Redo
     $("#editor-pane-nav-redo").click(function() {
       bramble.redo();
-      analytics.event({ category : "Editor UI", action : "Redo" });
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Redo" });
     });
 
     // Inspector
@@ -206,7 +206,7 @@ define(function(require) {
     bramble.on("inspectorChange", function(data) {
       if(data.enabled) {
         $("#preview-pane-nav-inspector").addClass("enabled");
-        analytics.event({ category : "Editor UI", action : "Inspector Enabled" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Inspector Enabled" });
       } else {
         $("#preview-pane-nav-inspector").removeClass("enabled");
       }
@@ -227,11 +227,11 @@ define(function(require) {
       if(enabled) {
         refreshWrapper.removeClass("enabled");
         bramble.disableAutoUpdate();
-        analytics.event({ category : "Editor UI", action : "Auto Update Toggle", label: "Disabled" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Auto Update Toggle", label: "Disabled" });
       } else {
         refreshWrapper.addClass("enabled");
         bramble.enableAutoUpdate();
-        analytics.event({ category : "Editor UI", action : "Auto Update Toggle", label: "Enabled" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Auto Update Toggle", label: "Enabled" });
       }
     });
 
@@ -240,7 +240,7 @@ define(function(require) {
       var el = $(this);
       el.removeClass("spin").width(el.width()).addClass("spin");
       bramble.refreshPreview();
-      analytics.event({ category : "Editor UI", action : "Refresh Preview"});
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Refresh Preview"});
     });
 
     // Preview vs. Tutorial preview mode. First check to see if there
@@ -276,7 +276,7 @@ define(function(require) {
       }
 
       bramble.hideTutorial(setNormalPreview);
-      analytics.event({ category : "Editor UI", action : "Tutorial Toggle", label: "Disabled" });
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Tutorial Toggle", label: "Disabled" });
     });
 
     $("#tutorial-title").click(function() {
@@ -285,7 +285,7 @@ define(function(require) {
       }
 
       bramble.showTutorial(setTutorialPreview);
-      analytics.event({ category : "Editor UI", action : "Tutorial Toggle", label: "Enabled" });
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Tutorial Toggle", label: "Enabled" });
     });
 
     // Programmatic change to tutorial vs. regular preview mode from Bramble
@@ -301,11 +301,11 @@ define(function(require) {
     // Preview Mode Toggle
     $("#preview-pane-nav-desktop").click(function() {
       activatePreviewMode("desktop");
-      analytics.event({ category : "EditorUI", action : "Preview Mode Toggle", label : "Desktop" });
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Preview Mode Toggle", label : "Desktop" });
     });
     $("#preview-pane-nav-phone").click(function() {
       activatePreviewMode("mobile");
-      analytics.event({ category : "EditorUI", action : "Preview Mode Toggle", label : "Mobile" });
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Preview Mode Toggle", label : "Mobile" });
     });
 
     function activatePreviewMode(mode) {
@@ -330,12 +330,12 @@ define(function(require) {
 
     $(".fullscreen-preview-toggle .enable-fullscreen").click(function() {
       enableFullscreenPreview();
-      analytics.event({ category : "EditorUI", action : "Fullscreen Preview Toggle", label : "Enabled"});
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Fullscreen Preview Toggle", label : "Enabled"});
     });
 
     $(".fullscreen-preview-toggle .disable-fullscreen").click(function() {
       disableFullscreenPreview();
-      analytics.event({ category : "EditorUI", action : "Fullscreen Preview Toggle", label : "Disabled"});
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Fullscreen Preview Toggle", label : "Disabled"});
     });
 
     function enableFullscreenPreview(){
@@ -375,7 +375,7 @@ define(function(require) {
         }
       });
 
-      analytics.event({ category : "Editor UI", action : "Publish Dialog Opened"});
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Publish Dialog Opened"});
     }
 
     function showPublishHelper() {
@@ -422,12 +422,12 @@ define(function(require) {
         $("#editor-pane-nav-options-menu").hide();
         $("#editor-pane-nav-fileview").css("display", "none");
         $(".filetree-pane-nav").css("display", "block");
-        analytics.event({ category : "EditorUI", action : "Toggle File View", label : "Show" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Toggle File View", label : "Show" });
       } else {
         $("#editor-pane-nav-options-menu").hide();
         $("#editor-pane-nav-fileview").css("display", "block");
         $(".filetree-pane-nav").css("display", "none");
-        analytics.event({ category : "EditorUI", action : "Toggle File View", label : "Hide" });
+        analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Toggle File View", label : "Hide" });
       }
     });
 

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -115,7 +115,7 @@ define(function(require) {
       e.preventDefault();
       e.stopPropagation();
 
-      analytics.event("NewProject", {label: "New authenticated project"});
+      analytics.event({ category : "Project Actions", action : "New Project", label : "New authenticated project" });
 
       var queryString = window.location.search;
       var cacheBust = "cacheBust=" + Date.now();
@@ -130,7 +130,8 @@ define(function(require) {
         return false;
       }
 
-      analytics.event("DeleteProject");
+      // Add label that it happened in the menu?
+      analytics.event({ category : "Project Actions", action : "Delete Project"});
 
       var request = $.ajax({
         headers: {
@@ -154,7 +155,7 @@ define(function(require) {
 
     $("#filetree-pane-nav-export-project-zip").click(function() {
       bramble.export();
-      analytics.event("ExportZip");
+      analytics.event({ category : "Project Actions", action : "Export ZIP"});
       return false;
     });
 
@@ -179,13 +180,13 @@ define(function(require) {
     // Undo
     $("#editor-pane-nav-undo").click(function() {
       bramble.undo();
-      analytics.event("Undo");
+      analytics.event({ category : "Editor UI", action : "Undo" });
     });
 
     // Redo
     $("#editor-pane-nav-redo").click(function() {
       bramble.redo();
-      analytics.event("Redo");
+      analytics.event({ category : "Editor UI", action : "Redo" });
     });
 
     // Inspector
@@ -205,10 +206,9 @@ define(function(require) {
     bramble.on("inspectorChange", function(data) {
       if(data.enabled) {
         $("#preview-pane-nav-inspector").addClass("enabled");
-        analytics.event("InspectorEnabled");
+        analytics.event({ category : "Editor UI", action : "Inspector Enabled" });
       } else {
         $("#preview-pane-nav-inspector").removeClass("enabled");
-        analytics.event("InspectorDisabled");
       }
 
       _inspectorEnabled = data.enabled;
@@ -218,7 +218,6 @@ define(function(require) {
     if(!bramble.getAutoUpdate()){
         $(".refresh-wrapper").removeClass("enabled");
         bramble.disableAutoUpdate();
-        analytics.event("disableAutoUpdate");
     }
 
     // Preview auto-refresh toggle
@@ -228,11 +227,11 @@ define(function(require) {
       if(enabled) {
         refreshWrapper.removeClass("enabled");
         bramble.disableAutoUpdate();
-        analytics.event("disableAutoUpdate");
+        analytics.event({ category : "Editor UI", action : "Auto Update Toggle", label: "Disabled" });
       } else {
         refreshWrapper.addClass("enabled");
         bramble.enableAutoUpdate();
-        analytics.event("enableAutoUpdate");
+        analytics.event({ category : "Editor UI", action : "Auto Update Toggle", label: "Enabled" });
       }
     });
 
@@ -241,13 +240,7 @@ define(function(require) {
       var el = $(this);
       el.removeClass("spin").width(el.width()).addClass("spin");
       bramble.refreshPreview();
-      analytics.event("RefreshPreview");
-    });
-
-    // Refresh Preview
-    $("#preview-pane-nav-refresh").click(function() {
-      bramble.refreshPreview();
-      analytics.event("RefreshPreview");
+      analytics.event({ category : "Editor UI", action : "Refresh Preview"});
     });
 
     // Preview vs. Tutorial preview mode. First check to see if there
@@ -269,15 +262,11 @@ define(function(require) {
     function setNormalPreview() {
       $("#tutorial-title").removeClass("preview-title-highlighted");
       $("#preview-title").addClass("preview-title-highlighted");
-
-      analytics.event("NormalPreview", {label: "User switched to normal preview mode vs. tutorial"});
     }
 
     function setTutorialPreview() {
       $("#preview-title").removeClass("preview-title-highlighted");
       $("#tutorial-title").addClass("preview-title-highlighted");
-
-      analytics.event("TutorialPreview", {label: "User switched to tutorial mode vs. preview"});
     }
 
     // User change to tutorial vs. regular preview mode
@@ -287,13 +276,16 @@ define(function(require) {
       }
 
       bramble.hideTutorial(setNormalPreview);
+      analytics.event({ category : "Editor UI", action : "Tutorial Toggle", label: "Disabled" });
     });
+
     $("#tutorial-title").click(function() {
       if(bramble.getTutorialVisible()) {
         return;
       }
 
       bramble.showTutorial(setTutorialPreview);
+      analytics.event({ category : "Editor UI", action : "Tutorial Toggle", label: "Enabled" });
     });
 
     // Programmatic change to tutorial vs. regular preview mode from Bramble
@@ -309,9 +301,11 @@ define(function(require) {
     // Preview Mode Toggle
     $("#preview-pane-nav-desktop").click(function() {
       activatePreviewMode("desktop");
+      analytics.event({ category : "EditorUI", action : "Preview Mode Toggle", label : "Desktop" });
     });
     $("#preview-pane-nav-phone").click(function() {
       activatePreviewMode("mobile");
+      analytics.event({ category : "EditorUI", action : "Preview Mode Toggle", label : "Mobile" });
     });
 
     function activatePreviewMode(mode) {
@@ -323,8 +317,6 @@ define(function(require) {
 
         $("#preview-pane-nav-desktop").removeClass("viewmode-active");
         $("#preview-pane-nav-desktop").addClass("viewmode-inactive");
-
-        analytics.event("MobilePreview");
       } else if (mode === "desktop") {
         bramble.useDesktopPreview();
 
@@ -333,22 +325,21 @@ define(function(require) {
 
         $("#preview-pane-nav-phone").removeClass("viewmode-active");
         $("#preview-pane-nav-phone").addClass("viewmode-inactive");
-
-        analytics.event("DesktopPreview");
       }
     }
 
     $(".fullscreen-preview-toggle .enable-fullscreen").click(function() {
       enableFullscreenPreview();
+      analytics.event({ category : "EditorUI", action : "Fullscreen Preview Toggle", label : "Enabled"});
     });
 
     $(".fullscreen-preview-toggle .disable-fullscreen").click(function() {
       disableFullscreenPreview();
+      analytics.event({ category : "EditorUI", action : "Fullscreen Preview Toggle", label : "Disabled"});
     });
 
     function enableFullscreenPreview(){
       $("body").addClass("fullscreen-preview");
-      analytics.event("FullscreenPreviewOn");
       // In case it's on, turn off the inspector
       bramble.disableInspector();
       bramble.enableFullscreenPreview();
@@ -356,7 +347,6 @@ define(function(require) {
 
     function disableFullscreenPreview(){
       $("body").removeClass("fullscreen-preview");
-      analytics.event("FullscreenPreviewOff");
       bramble.disableFullscreenPreview();
     }
 
@@ -385,7 +375,7 @@ define(function(require) {
         }
       });
 
-      analytics.event("Publish");
+      analytics.event({ category : "Editor UI", action : "Publish Dialog Opened"});
     }
 
     function showPublishHelper() {
@@ -432,14 +422,12 @@ define(function(require) {
         $("#editor-pane-nav-options-menu").hide();
         $("#editor-pane-nav-fileview").css("display", "none");
         $(".filetree-pane-nav").css("display", "block");
-
-        analytics.event("ShowSidebar");
+        analytics.event({ category : "EditorUI", action : "Toggle File View", label : "Show" });
       } else {
         $("#editor-pane-nav-options-menu").hide();
         $("#editor-pane-nav-fileview").css("display", "block");
         $(".filetree-pane-nav").css("display", "none");
-
-        analytics.event("HideSidebar");
+        analytics.event({ category : "EditorUI", action : "Toggle File View", label : "Hide" });
       }
     });
 

--- a/public/editor/scripts/editor/js/fc/project-rename.js
+++ b/public/editor/scripts/editor/js/fc/project-rename.js
@@ -136,7 +136,7 @@ define(function(require) {
             return;
           }
           editingComplete(context);
-          analytics.event({ category : "Project Actions", action : "Rename Project" });
+          analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "Rename Project" });
 
           context.publisher.showUnpublishedChangesPrompt();
         });

--- a/public/editor/scripts/editor/js/fc/project-rename.js
+++ b/public/editor/scripts/editor/js/fc/project-rename.js
@@ -136,7 +136,7 @@ define(function(require) {
             return;
           }
           editingComplete(context);
-          analytics.event("ProjectRenamed");
+          analytics.event({ category : "Project Actions", action : "Rename Project" });
 
           context.publisher.showUnpublishedChangesPrompt();
         });

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -17,7 +17,7 @@ require.config({
     "PathCache": "../../path-cache",
     "constants": "../../constants",
     "EventEmitter": "/node_modules/wolfy87-eventemitter/EventEmitter.min",
-    "analytics": "/node_modules/webmaker-analytics/analytics"
+    "analytics": "../../analytics"
   },
   shim: {
     "jquery": {
@@ -70,7 +70,7 @@ require(["jquery", "bowser"], function($, bowser) {
       if(!projectDetails.userID){
         ProjectRenameUtility.init(appUrl, BrambleEditor.csrfToken);
       }
-     
+
       // Initialize the login links
       SSOOverride.init();
 

--- a/public/editor/scripts/project-list.js
+++ b/public/editor/scripts/project-list.js
@@ -92,7 +92,7 @@ require(["jquery", "constants", "analytics", "moment"], function($, Constants, a
     var projectElementId = project.attr("id");
     $("#" + projectElementId + " > .project-title").off("click");
 
-    analytics.event("DeleteProject");
+    analytics.event({ category : "Project Actions", action : "Delete Project" });
 
     var request = $.ajax({
       headers: {
@@ -141,7 +141,7 @@ function setupNewProjectLinks($, analytics) {
 
     $(e.target).text("{{ newProjectInProgressIndicator }}");
 
-    analytics.event("NewProject", {label: "New authenticated project"});
+    analytics.event({ category : "Project Actions", action : "New Authenticated Project" });
     window.location.href = "/" + locale + "/projects/new" + qs;
   }
 

--- a/public/editor/scripts/project-list.js
+++ b/public/editor/scripts/project-list.js
@@ -92,7 +92,7 @@ require(["jquery", "constants", "analytics", "moment"], function($, Constants, a
     var projectElementId = project.attr("id");
     $("#" + projectElementId + " > .project-title").off("click");
 
-    analytics.event({ category : "Project Actions", action : "Delete Project" });
+    analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "Delete Project" });
 
     var request = $.ajax({
       headers: {
@@ -141,7 +141,7 @@ function setupNewProjectLinks($, analytics) {
 
     $(e.target).text("{{ newProjectInProgressIndicator }}");
 
-    analytics.event({ category : "Project Actions", action : "New Authenticated Project" });
+    analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "New Authenticated Project" });
     window.location.href = "/" + locale + "/projects/new" + qs;
   }
 

--- a/public/homepage/scripts/gallery.js
+++ b/public/homepage/scripts/gallery.js
@@ -37,8 +37,8 @@ define(["jquery", "analytics"], function($, analytics) {
       this.galleryEl.on("keydown",".search",function(e){ that.keyPressed(e); });
       this.galleryEl.on("mousedown",".tag",function(){  that.tagClicked($(this).attr("tag")); });
 
-      this.galleryEl.on("click",".activity .thumbnail",function(e){ that.thumbnailClicked($(this)); });
-      this.galleryEl.on("click",".activity .remix",function(e){ that.thumbnailClicked($(this)); });
+      this.galleryEl.on("click",".activity .thumbnail",function(){ that.thumbnailClicked($(this)); });
+      this.galleryEl.on("click",".activity .remix",function(){ that.remixClicked($(this)); });
 
       this.galleryEl.on("click",".search-tags .remove",function(){ that.removeTag($(this).parent()); });
       this.galleryEl.on("click",".start-over",function(e){ that.startOver(e); });
@@ -58,7 +58,7 @@ define(["jquery", "analytics"], function($, analytics) {
     },
 
     //When a Project gets remixed
-    thumbnailClicked: function(el){
+    remixClicked: function(el){
       var title = el.closest(".activity").find(".title").text();
       analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Gallery Project Remixed", label : title });
     },

--- a/public/homepage/scripts/gallery.js
+++ b/public/homepage/scripts/gallery.js
@@ -54,13 +54,13 @@ define(["jquery", "analytics"], function($, analytics) {
     //When a Project preview gets clicked
     thumbnailClicked: function(el){
       var title = el.closest(".activity").find(".title").text();
-      analytics.event({ category : "Homepage", action : "Gallery Project Viewed", label : title });
+      analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Gallery Project Viewed", label : title });
     },
 
     //When a Project gets remixed
     thumbnailClicked: function(el){
       var title = el.closest(".activity").find(".title").text();
-      analytics.event({ category : "Homepage", action : "Gallery Project Remixed", label : title });
+      analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Gallery Project Remixed", label : title });
     },
 
     // Removes one of the tags that is currently being used as a filter
@@ -149,7 +149,7 @@ define(["jquery", "analytics"], function($, analytics) {
       // Send analytics event
       var searchQuery = this.searchTerms.join(" ");
       if(searchQuery.length > 0 && searchQuery != this.lastSearchString) {
-        analytics.event({ category : "Homepage", action : "Keyword Search", label : searchQuery });
+        analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Keyword Search", label : searchQuery });
       }
       this.lastSearchString = searchQuery;
 
@@ -294,7 +294,7 @@ define(["jquery", "analytics"], function($, analytics) {
         that.galleryEl.find(".search-wrapper").removeClass("pop");
       },200);
 
-      analytics.event({ category : "Homepage", action : "Gallery Tag Clicked", label : term });
+      analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Gallery Tag Clicked", label : term });
     },
 
     // Updates the tags & activities UI

--- a/public/homepage/scripts/gallery.js
+++ b/public/homepage/scripts/gallery.js
@@ -1,4 +1,4 @@
-define(["jquery"], function($) {
+define(["jquery", "analytics"], function($, analytics) {
 
   var gallery = {
 
@@ -9,6 +9,7 @@ define(["jquery"], function($) {
     searchTerms : [],     // Search terms from the input
     maxDisplayTags : 5,   // Max number of tags to show above results
     resultsTimeoutMS : 200,  // Visual delay for displaying updated results & tags
+    lastSearchString : false,
 
     // Fetch external activity data
     init: function() {
@@ -35,6 +36,10 @@ define(["jquery"], function($) {
       this.galleryEl.on("click",".clear",function(){ that.clearSearch(); });
       this.galleryEl.on("keydown",".search",function(e){ that.keyPressed(e); });
       this.galleryEl.on("mousedown",".tag",function(){  that.tagClicked($(this).attr("tag")); });
+
+      this.galleryEl.on("click",".activity .thumbnail",function(e){ that.thumbnailClicked($(this)); });
+      this.galleryEl.on("click",".activity .remix",function(e){ that.thumbnailClicked($(this)); });
+
       this.galleryEl.on("click",".search-tags .remove",function(){ that.removeTag($(this).parent()); });
       this.galleryEl.on("click",".start-over",function(e){ that.startOver(e); });
 
@@ -44,6 +49,18 @@ define(["jquery"], function($) {
       setTimeout(function(){
         that.galleryEl.removeClass("loading");
       }, this.resultsTimeoutMS);
+    },
+
+    //When a Project preview gets clicked
+    thumbnailClicked: function(el){
+      var title = el.closest(".activity").find(".title").text();
+      analytics.event({ category : "Homepage", action : "Gallery Project Viewed", label : title });
+    },
+
+    //When a Project gets remixed
+    thumbnailClicked: function(el){
+      var title = el.closest(".activity").find(".title").text();
+      analytics.event({ category : "Homepage", action : "Gallery Project Remixed", label : title });
     },
 
     // Removes one of the tags that is currently being used as a filter
@@ -78,7 +95,6 @@ define(["jquery"], function($) {
         that.filterActivities();
       }, that.searchSpeedMS);
     },
-
 
     // Determines which activities should be displayed
     filterActivities : function(){
@@ -129,6 +145,13 @@ define(["jquery"], function($) {
           }
         }
       }
+
+      // Send analytics event
+      var searchQuery = this.searchTerms.join(" ");
+      if(searchQuery.length > 0 && searchQuery != this.lastSearchString) {
+        analytics.event({ category : "Homepage", action : "Keyword Search", label : searchQuery });
+      }
+      this.lastSearchString = searchQuery;
 
       this.galleryEl.find(".popular-tags, .activities").addClass("fade");
       this.updateUI();
@@ -270,6 +293,8 @@ define(["jquery"], function($) {
       setTimeout(function(){
         that.galleryEl.find(".search-wrapper").removeClass("pop");
       },200);
+
+      analytics.event({ category : "Homepage", action : "Gallery Tag Clicked", label : term });
     },
 
     // Updates the tags & activities UI

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -16,7 +16,7 @@ require.config({
     "localized": "/node_modules/webmaker-i18n/localized",
     "uuid": "/node_modules/node-uuid/uuid",
     "cookies": "/node_modules/cookies-js/dist/cookies",
-    "analytics": "/node_modules/webmaker-analytics/analytics",
+    "analytics": "/{{ locale }}/editor/scripts/analytics",
     "gallery": "/{{ locale }}/homepage/scripts/gallery",
     // TODO: we should really put the homepage and editor in the same scope for code sharing
     "fc/bramble-popupmenu": "/{{ locale }}/editor/scripts/editor/js/fc/bramble-popupmenu",
@@ -64,10 +64,10 @@ function setupNewProjectLinks($, analytics) {
     $("#new-project-button-text").text("{{ newProjectInProgressIndicator }}");
 
     if(authenticated) {
-      analytics.event("NewProject", {label: "New authenticated project"});
+      analytics.event({ category : "Homepage", action : "New Authenticated Project" });
       window.location.href = "/" + locale + "/projects/new" + qs;
     } else {
-      analytics.event("NewProject", {label: "New anonymous project"});
+      analytics.event({ category : "Homepage", action : "New Anonymous Project" });
       window.location.href = "/" + locale + "/editor" + queryString;
     }
   }
@@ -95,10 +95,10 @@ function setupAuthentication($, uuid, cookies, analytics) {
       var location = loginUrl;
 
       if (newUser) {
-        analytics.event("SignUp");
+        analytics.event({ category : "Homepage", action : "Create Account" });
         location += "?signup=true";
       } else {
-        analytics.event("SignIn");
+        analytics.event({ category : "Homepage", action : "Sign In" });
       }
 
       window.location = location;

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -64,10 +64,10 @@ function setupNewProjectLinks($, analytics) {
     $("#new-project-button-text").text("{{ newProjectInProgressIndicator }}");
 
     if(authenticated) {
-      analytics.event({ category : "Homepage", action : "New Authenticated Project" });
+      analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "New Authenticated Project" });
       window.location.href = "/" + locale + "/projects/new" + qs;
     } else {
-      analytics.event({ category : "Homepage", action : "New Anonymous Project" });
+      analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "New Anonymous Project" });
       window.location.href = "/" + locale + "/editor" + queryString;
     }
   }
@@ -95,10 +95,10 @@ function setupAuthentication($, uuid, cookies, analytics) {
       var location = loginUrl;
 
       if (newUser) {
-        analytics.event({ category : "Homepage", action : "Create Account" });
+        analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Create Account" });
         location += "?signup=true";
       } else {
-        analytics.event({ category : "Homepage", action : "Sign In" });
+        analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Sign In" });
       }
 
       window.location = location;


### PR DESCRIPTION
Fixes #1794 

**Changes**

* Ripped out the ``webmaker-analytics`` node module and put the code into ``public/editor/analytics.js`` instead
* Removed Optimizely references from the analytics code
* Removed the Fallback old way of doing Events
* Rewrote all events to have separate cateogries
* Linked events to UI actions
  * We only count a theme toggle when the user does it explicitly, not when we set it on refresh
* Paired events together so there is a "Enabled" and "Disabled" label with the same action like "Toggle Javascript"
* Added some analytics events to the new homepage Gallery

I think that's it - can I get a look-over @humphd 