### PR TITLE
Fix #1956: Added hover state to Homepage Gallery Remix Button

### DIFF
--- a/public/homepage/stylesheets/gallery.less
+++ b/public/homepage/stylesheets/gallery.less
@@ -182,6 +182,11 @@
         border: solid 2px #51b56b;
         padding-bottom: 14px;
         border-bottom: solid 3px rgba(0,0,0,.2);
+        transition: opacity .1s ease-out;
+
+        &:hover {
+	  opacity: .85;
+        }
       }
 
       .teaching-kit {


### PR DESCRIPTION
Here is the fix for the hover state. 
I have just used the same technique that was used for hovering tag buttons on the homepage (by changing the opacity of buttons). 

Here is how it looks: 

![hover](https://cloud.githubusercontent.com/assets/13225708/24733481/0f5a6402-1a46-11e7-8c37-e373de47e524.gif)

Fixes #1956