### PR TITLE
Fix #1962: Scrollable Language Menu

### DIFF
--- a/public/resources/stylesheets/userbar.less
+++ b/public/resources/stylesheets/userbar.less
@@ -385,6 +385,8 @@ a.navbar-login:hover {
     text-align: left;
     color: black;
     position: absolute;
+    overflow: auto;
+    max-height: ~"calc(100vh - 85px)";
     min-width: 185px;
     top: 43px;
     left: 0;


### PR DESCRIPTION
Is this okay? I have it extend just above the green portion of the page.

![9bc42e0dbc3f62b4f766d4f791564a6c](https://cloud.githubusercontent.com/assets/14262279/24809132/8659e41e-1b8c-11e7-950a-fe651f9184b5.png)