### PR TITLE
Fix#1921: Extended the Gruntfile to include eslint 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "env": {
+    "node": true,
+    "browser": true
+  },
+
+  "rules": {
+    "indent": ["error", 2]
+  },
+
+  "parserOptions": {
+    "ecmaVersion": 6
+  }
+  
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,10 +131,21 @@ module.exports = function( grunt ) {
           ]
         }
       }
+    },
+    eslint: {
+      src: [
+        "public/homepage/**/*.js",
+        "public/resources/remix/index.js",
+        "!public/homepage/scripts/google-analytics.js",
+        "!public/editor/scripts/google-analytics.js",
+        "server/**/*.js",
+        "scripts/*.js",
+        "*.js"
+      ]
     }
   });
 
-  grunt.registerTask("test", [ "jshint:server", "jshint:frontend", "lesslint" ]);
+  grunt.registerTask("test", [ "jshint:server", "jshint:frontend", "lesslint", "eslint" ]);
   grunt.registerTask("build", [ "test", "requirejs:dist" ]);
   grunt.registerTask("default", [ "test" ]);
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-less": "^1.4.0",
     "grunt-contrib-requirejs": "^1.0.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-execute": "0.2.2",
     "grunt-git": "^0.3.4",
     "grunt-lesslint": "^1.1.14",

--- a/server/index.js
+++ b/server/index.js
@@ -32,7 +32,7 @@ let homepageVideoLink = "https://www.youtube.com/embed/JecFOjD9I3k";
 /*
  * Local server variables
  */
- server.locals.APP_HOSTNAME = env.get("APP_HOSTNAME");
+server.locals.APP_HOSTNAME = env.get("APP_HOSTNAME");
 server.locals.GA_ACCOUNT = env.get("GA_ACCOUNT");
 server.locals.GA_DOMAIN = env.get("GA_DOMAIN");
 server.locals.node_path = "node_modules";
@@ -111,7 +111,7 @@ server.use("/resources/remix", express.static(path.join(root, "public/resources/
  * L10N
  */
 localize(server, Object.assign(env.get("L10N"), {
-   excludeLocaleInUrl: [ "/projects/remix-bar" ]
+  excludeLocaleInUrl: [ "/projects/remix-bar" ]
 }));
 
 
@@ -130,4 +130,4 @@ server.use(HttpError.notFound);
 /*
  * export the server object
  */
- module.exports = server;
+module.exports = server;

--- a/server/lib/middleware.js
+++ b/server/lib/middleware.js
@@ -46,8 +46,8 @@ module.exports = function middlewareConstructor() {
       return function(req, res, next) {
         req.errorMessageKey = typeof errorMessageKey === "function" ? errorMessageKey(req) : errorMessageKey;
         next();
-       };
-     },
+      };
+    },
 
     /**
      * Check whether the requesting user has been authenticated.

--- a/server/routes/projects/read.js
+++ b/server/routes/projects/read.js
@@ -70,7 +70,7 @@ module.exports = function(config, req, res, next) {
 
     //Sort projects in ascending order by last updated
     projects.sort(function(project1, project2) {
-        return new Date(project2.date_updated).getTime() - new Date(project1.date_updated).getTime();
+      return new Date(project2.date_updated).getTime() - new Date(project1.date_updated).getTime();
     });
 
     var options = {

--- a/server/routes/utils.js
+++ b/server/routes/utils.js
@@ -152,7 +152,7 @@ function updateProject(config, user, data, callback) {
 
   var project;
   try {
-   project = JSON.parse(JSON.stringify(data));
+    project = JSON.parse(JSON.stringify(data));
   } catch(e) {
     callback({
       message: "Project sent by calling function was in an invalid format. Failed to run `JSON.parse`",


### PR DESCRIPTION
@Pomax I installed eslint for grunt and modified the Gruntfile.js file to include the eslint task.
The only rule I can think of to enable and check for is the indent rule. I added it in the .eslintrc.json file and specified that the indent needs to be 2 spaces. If there are any other rules I need to add please let me know.
I also specified the ecmaVersion for the parser to be 6 because if I don't it will give many parsing errors like the keyword `let` is reserved and `const` is reserved.  
Currently when I run `npm test` I get 7 errors because some files don't use 2 spaces. This is how the errors look: 
<img width="694" alt="screen shot 2017-04-09 at 2 59 35 pm" src="https://cloud.githubusercontent.com/assets/12388934/24840122/389c172e-1d35-11e7-9c63-dc68fa1ad1c6.png">
