### PR TITLE
Show tutorial by default when available at project load. Fixes #1776

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -290,7 +290,7 @@ define(function(require) {
 
     // Programmatic change to tutorial vs. regular preview mode from Bramble
     bramble.on("tutorialVisibilityChange", function(data) {
-      if(data.visibility) {
+      if(data.visible) {
         setTutorialPreview();
       } else {
         setNormalPreview();

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -244,15 +244,21 @@ define(function(require) {
               return callback(err);
             }
 
-            // Look for an HTML file to open, ideally index.html
-            var indexPos = 0;
+            // Look for an HTML file to open
+            // Preferably `tutorial.html` (if available) or `index.html`
+            // Otherwise the first html file available
+            var indexPos = 0, tutorialPos = -1;
             found.forEach(function(path, idx) {
-              if(Path.basename(path) === "index.html") {
+              if(Path.basename(path) === "tutorial.html") {
+                tutorialPos = idx;
+              }
+
+              if (Path.basename(path) === "index.html") {
                 indexPos = idx;
               }
             });
 
-            callback(null, found[indexPos]);
+            callback(null, found[tutorialPos >= 0 ? tutorialPos : indexPos]);
           });
         });
       });


### PR DESCRIPTION
As discussed in #1776. 

Does two things:
+ Fixes a typo that was preventing the `bramble:tutorialVisibilityChange` event from being interpreted correctly in the Thimble client.
+ Shows the Tutorial by default if available. If not, shows Index HTML file. Otherwise falls back to showing the first HTML file available in file list. This preserves behaviour from previous code.

Note that [Bramble #722](https://github.com/mozilla/brackets/pull/722) must land before this PR for it to work.