### PR TITLE
Fix #1524:  Removing previous patch of mozillathimblelivepreview script preloading in homepage  

### DIFF
--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -1,5 +1,3 @@
-/* global requirejs */
-
 require.config({
   waitSeconds: 120,
   baseUrl: "/{{ locale }}/homepage/scripts",

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -107,7 +107,6 @@ function init($, uuid, cookies, PopupMenu, analytics, gallery) {
   setupAuthentication($, uuid, cookies, analytics);
   setupNewProjectLinks($, analytics);
   gallery.init();
-  preloadBramble($);
 }
 
 require(['jquery', 'uuid', 'cookies', 'fc/bramble-popupmenu', 'analytics', 'gallery'], init);

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -30,21 +30,6 @@ require.config({
   }
 });
 
-// While the user is reading this page, start to cache Bramble's biggest files
-function preloadBramble($) {
-  var brambleHost = $("meta[name='bramble-host']").attr("content");
-  brambleHost = brambleHost.replace(/\/$/, "");
-  [
-    brambleHost + "/dist/styles/brackets.min.css",
-    brambleHost + "/dist/bramble.js",
-    brambleHost + "/dist/main.js",
-    brambleHost + "/dist/thirdparty/thirdparty.min.js"
-  ].forEach(function(url) {
-    // Load and cache files as plain text (don't parse) and ignore results.
-    $.ajax({url: url, dataType: "text"});
-  });
-}
-
 function setupNewProjectLinks($, analytics) {
   var authenticated = $("#navbar-login").hasClass("signed-in");
   var newProjectButton = $("#new-project-button");

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -1,3 +1,5 @@
+/* global requirejs */
+
 require.config({
   waitSeconds: 120,
   baseUrl: "/{{ locale }}/homepage/scripts",

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -1,4 +1,4 @@
-/* global requirejs */
+// global requirejs 
 
 require.config({
   waitSeconds: 120,

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -1,13 +1,5 @@
 /* global requirejs */
 
-// Because we pre-load require scripts needed by the editor, we need to
-// eat error messages related to fetching but not using those modules.
-requirejs.onError = function(err) {
-  if(err.requireType !== "mismatch") {
-    throw err;
-  }
-};
-
 require.config({
   waitSeconds: 120,
   baseUrl: "/{{ locale }}/homepage/scripts",

--- a/views/homepage/index.html
+++ b/views/homepage/index.html
@@ -5,7 +5,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-    <meta name="bramble-host" content="{{editorHOST}}">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@mozlearn">


### PR DESCRIPTION
Working on fixing the second part of issue [1524](https://github.com/mozilla/thimble.mozilla.org/issues/1524) 