### PR TITLE
Fixes #1948, Remove strange effect on items deleted from Your Projects list

### DIFF
--- a/public/editor/scripts/project-list.js
+++ b/public/editor/scripts/project-list.js
@@ -112,10 +112,8 @@ require(["jquery", "constants", "analytics", "moment"], function($, Constants, a
       console.error(err);
     });
 
-    project.fadeOut({
-      duration: "slow",
-      easing: "linear",
-      complete: function(){
+    project.slideToggle( {
+      complete: function() {
         project.remove();
       }
     });

--- a/public/editor/scripts/project-list.js
+++ b/public/editor/scripts/project-list.js
@@ -112,10 +112,10 @@ require(["jquery", "constants", "analytics", "moment"], function($, Constants, a
       console.error(err);
     });
 
-    project.hide({
-      duration: 250,
+    project.fadeOut({
+      duration: "slow",
       easing: "linear",
-      done: function() {
+      complete: function(){
         project.remove();
       }
     });


### PR DESCRIPTION
fixes issue number #1948 
Removed project.hide() in project-list.js and replaced it with project.fadeOut().

The slide-to-left animation before a project was deleted was unwanted and a fade out effect was preferred. 
![ezgif-3-474b4b8d0a](https://cloud.githubusercontent.com/assets/11840234/25293708/1323d792-26aa-11e7-88a2-acc61891b7cb.gif)
