### PR TITLE
Fix #2018: Don't keep sync pending if local file vanishes during update

### DIFF
--- a/public/editor/scripts/editor/js/fc/sync-manager.js
+++ b/public/editor/scripts/editor/js/fc/sync-manager.js
@@ -169,7 +169,7 @@ define(function(require) {
       if(err) {
         // Deal with case of local file vanishing before we get a chance to sync (#2018).
         if(err.code === "ENOENT") {
-          logger("SyncManager", "local file missing for sync update operation, skipping: ", currentPath);
+          logger("SyncManager", "local file missing for sync update operation, skipping: ", path);
           return callback();
         }
         return callback(err);

--- a/public/editor/scripts/editor/js/fc/sync-manager.js
+++ b/public/editor/scripts/editor/js/fc/sync-manager.js
@@ -167,6 +167,11 @@ define(function(require) {
 
     fs.readFile(path, function(err, data) {
       if(err) {
+        // Deal with case of local file vanishing before we get a chance to sync (#2018).
+        if(err.code === "ENOENT") {
+          logger("SyncManager", "local file missing for sync update operation, skipping: ", currentPath);
+          return callback();
+        }
         return callback(err);
       }
 
@@ -281,7 +286,7 @@ define(function(require) {
 
     self.setSyncing(true);
 
-    function finalizeOperation(ajaxError) {
+    function finalizeOperation(operationErr) {
       Project.getSyncQueue(function(err, syncQueue) {
         if(err) {
           self.emitErrorEvent(err);
@@ -312,7 +317,7 @@ define(function(require) {
               // If the last operation errored, apply a backoff delay.
               delay = (self.backoff && self.backoff.next()) || AJAX_DEFAULT_DELAY_MS;
 
-              logger("SyncManager", "finished current operation (" + (ajaxError ? "failed" : "success") + "), will run next in " + delay + "ms. " + self.getPendingCount() + " operation(s) remain.");
+              logger("SyncManager", "finished current operation (" + (operationErr ? "failed" : "success") + "), will run next in " + delay + "ms. " + self.getPendingCount() + " operation(s) remain.");
               setTimeout(self.runNextOperation.bind(self), delay);
             } else {
               self.setSyncing(false);
@@ -339,8 +344,10 @@ define(function(require) {
 
         // If the network operation errored, put this file operation back in the pending list
         // and create a backoff delay object.  If it worked, remove a previous backoff delay (if any).
-        if(ajaxError) {
-          logger("SyncManager", "error syncing file, requeuing operation", ajaxError);
+        // Deal with any cases where the local file has vanished, and we should give up instead.
+        if(operationErr) {
+          logger("SyncManager", "error syncing file: ", operationErr,
+                 "Requeuing operation: ", currentOperation, " for path", currentPath);
           self.trigger("file-sync-error");
           queueOperation();
 

--- a/public/editor/scripts/logger.js
+++ b/public/editor/scripts/logger.js
@@ -26,6 +26,7 @@ define(function() {
       return log;
     }
 
+    console.info("[Thimble] to see detailed logging info in the console, reload with ?logging=1 on the URL.");
     return noop;
   }(window.location.search));
 });


### PR DESCRIPTION
I can't reproduce the bug the user had in #2018, but I think this a good start toward making things better.  The bug is that we have a pending file path to sync, but when we go to read the file from the local fs, it isn't there.  Here I check to see if we've hit an `ENOENT` while trying to read the current path in an update operation, and if so, I allow the sync operation to complete.  What happens now is that we fail forever, as we retry to sync the path, which is never there.

I don't think there are other cases for delete/rename that need this same treatment, but please look over the code and see if you agree.  I also can't think of other error cases we should treat this way for `readFile`, but maybe there are some I'm missing?

I've also added a console log to tell people how to get detailed logging info, which is key if you want to debug any syncing issues. 