### PR TITLE
The project list now scrolls when it should.

### DIFF
--- a/public/editor/stylesheets/projects-style.less
+++ b/public/editor/stylesheets/projects-style.less
@@ -1,8 +1,12 @@
 @import "variables.less";
 
+body {
+  overflow: auto;
+}
+
 .project-list-wrapper {
   width: ~"calc(100% - 100px)";
-  margin: 35px auto;
+  margin: 35px auto 60px auto;
   position: relative;
   max-width: 1024px;
 }


### PR DESCRIPTION
To test, load up the ``/projects`` view ("Your Projects") and test that when the browser window is too short to accommodate all of your projects, the page will scroll.

Fixes #2044

