### PR TITLE
"Won't load" help message on green loading screen.

### DIFF
--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -39,6 +39,9 @@ errorUnsupportedBrowserSuggestion=Thimble works in all of the following browsers
 errorUnsupportedBrowserIgnore=Let me try anyway!
 errorLoadingProjectBramble=For error details open your browser's Developer Tools console.
 refreshForUpdates=<strong>Thimble has Updates</strong> - Please refresh your browser to get the latest changes. <button class="refresh-browser">Refresh</button>
+projectNotLoadingMessage=If your project doesn't load, <br>please reload the page to try again.
+tryAgainButtonLabel=Try Again
+emailForHelp=If that doesn't help, <a href="mailto:thimble@mozillafoundation.org">let us know</a>.
 
 # Userbar
 renameProjectSaveBtn=Save

--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -39,7 +39,7 @@ errorUnsupportedBrowserSuggestion=Thimble works in all of the following browsers
 errorUnsupportedBrowserIgnore=Let me try anyway!
 errorLoadingProjectBramble=For error details open your browser's Developer Tools console.
 refreshForUpdates=<strong>Thimble has Updates</strong> - Please refresh your browser to get the latest changes. <button class="refresh-browser">Refresh</button>
-projectNotLoadingMessage=If your project doesn't load, <br>please reload the page to try again.
+projectNotLoadingMessage=Your project seems to be taking a long time to load.<br/> If it doesn't load, please reload the page to try again.
 tryAgainButtonLabel=Try Again
 emailForHelp=If that doesn't help, <a href="mailto:thimble@mozillafoundation.org">let us know</a>.
 

--- a/public/editor/scripts/analytics.js
+++ b/public/editor/scripts/analytics.js
@@ -18,6 +18,7 @@
   eventCategories.EDITOR_UI = "Editor UI";
   eventCategories.HOMEPAGE = "Homepage";
   eventCategories.PROJECT_ACTIONS = "Project Actions";
+  eventCategories.TROUBLESHOOTING = "Troubleshooting";
 
   var _redacted = "REDACTED (Potential Email Address)";
 

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -52,6 +52,16 @@ require(["jquery", "bowser"], function($, bowser) {
 
   Bramble.once("error", onError);
 
+  var errorMessageTimeoutMS = 10000;
+
+  setTimeout(function(){
+    showLoadingErrorMessage();
+  }, errorMessageTimeoutMS);
+
+  function showLoadingErrorMessage(){
+    $("#spinner-container .taking-too-long").addClass("visible");
+  }
+
   $("button.refresh-browser").on("click",function(){
     window.location.reload(true);
   });

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -26,7 +26,7 @@ require.config({
   }
 });
 
-require(["jquery", "bowser"], function($, bowser) {
+require(["jquery", "bowser", "analytics"], function($, bowser, analytics) {
   // Warn users of unsupported browsers that they can try something newer,
   // specifically anything before IE 11 or Safari 8.
   if((bowser.msie && bowser.version < 11) || (bowser.safari && bowser.version < 8)) {
@@ -52,7 +52,7 @@ require(["jquery", "bowser"], function($, bowser) {
 
   Bramble.once("error", onError);
 
-  var errorMessageTimeoutMS = 10000;
+  var errorMessageTimeoutMS = 15000;
 
   setTimeout(function(){
     showLoadingErrorMessage();
@@ -60,10 +60,12 @@ require(["jquery", "bowser"], function($, bowser) {
 
   function showLoadingErrorMessage(){
     $("#spinner-container .taking-too-long").addClass("visible");
+    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Not loading message shown" });
   }
 
   $("button.refresh-browser").on("click",function(){
     window.location.reload(true);
+    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Refresh button clicked" });
   });
 
   Bramble.once("updatesAvailable", function() {
@@ -72,6 +74,7 @@ require(["jquery", "bowser"], function($, bowser) {
 
   function showRefreshAlert(){
     console.log("Thimble has updates - please refresh your browser to get the latest changes.");
+    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Updates available UI shown" });
     $("body").addClass("has-alert-bar");
     $("#serviceworker-warning").removeClass("hide");
   }

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -64,8 +64,8 @@ require(["jquery", "bowser", "analytics"], function($, bowser, analytics) {
   }
 
   $("button.refresh-browser").on("click",function(){
-    window.location.reload(true);
     analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Refresh button clicked" });
+    window.location.reload(true);
   });
 
   Bramble.once("updatesAvailable", function() {

--- a/views/editor/bramble.html
+++ b/views/editor/bramble.html
@@ -21,7 +21,7 @@
 
         #spinner-container h2 {
             color: white;
-            font-size: 18px;
+            font-size: 20px;
             margin: 0 0 5px 0;
         }
 
@@ -37,10 +37,6 @@
 
         #spinner-container.loading-error .error-message {
             display: block;
-        }
-
-        #spinner-container .loading-message {
-            animation: loadingpulse 1s infinite linear;
         }
 
         #spinner-container a {
@@ -105,21 +101,6 @@
           color: black;
         }
 
-        @keyframes loadingpulse {
-            0% {
-                transform: scale(1);
-                opacity: .4;
-            }
-            50% {
-                transform: scale(1.02);
-                opacity: .6;
-            }
-            100% {
-                transform: scale(1);
-                opacity: .4;
-            }
-        }
-
         @keyframes spinner {
             0% {
                 transform: rotateX(0deg) rotateY(0deg);
@@ -138,11 +119,48 @@
             }
         }
 
+        #spinner-container .taking-too-long {
+          max-height: 0;
+          opacity: 0;
+          overflow: hidden;
+          padding-top: 30px;
+          transition: max-height 1s ease-out 0s, opacity 1s ease-out .25s;
+          margin: 0 auto;
+        }
+
+        #spinner-container .taking-too-long p {
+            margin: 0 0 10px 0;
+        }
+
+        #spinner-container .taking-too-long p.email-us {
+            margin: 50px 0 0 0;
+        }
+
+
+        #spinner-container .taking-too-long.visible {
+          max-height: 400px;
+          opacity: 1;
+        }
+
         </style>
 
     <div id="spinner-container">
         <div class="thimble-spinner"></div>
-        <div class="loading-message message">{{ gettext("loadingProject") }}</div>
+        <div class="loading-message message">
+            <h2>{{ gettext("loadingProject") }}</h2>
+            <div class="taking-too-long">
+                <p>
+                  {{ gettext("projectNotLoadingMessage") | safe }}
+                </p>
+                <p>
+                  <button class="refresh-browser">{{ gettext("tryAgainButtonLabel") }}</button>
+                </p>
+                <p class="email-us">
+                  {{ gettext("emailForHelp") | safe }}
+                </p>
+            </div>
+        </div>
+
         <div class="error-message message">
             <h2>
               {{ gettext("somethingWentWrong") }}


### PR DESCRIPTION
This patch adds the following message to the loading screen...

<img src="https://cloud.githubusercontent.com/assets/25212/25964360/6e233270-3639-11e7-99b8-f8ec47e2af6e.png" width="350" />

It should appear after 10 seconds if the project hasn't loaded. For testing, you can make it appear faster by modifying ``var errorMessageTimeoutMS = 10000;`` [in this file](https://github.com/mozilla/thimble.mozilla.org/compare/master...flukeout:loading-screen-message?expand=1#diff-270f212d36b8a2447fd4f97c986a0b06R55)

cc @humphd 