### PR TITLE
Homepage nav items should open their localized pages

### DIFF
--- a/views/homepage/userbar.html
+++ b/views/homepage/userbar.html
@@ -9,9 +9,9 @@
       </div>
       <div class="main-nav">
 
-        <a href="/" class="{% if pageName == 'home' %}selected{% endif %}">{{ gettext("userbarGetStarted") }}</a>
-        <a href="/features" class="{% if pageName == 'features' %}selected{% endif %}">{{ gettext("userbarCoolFeatures") }}</a>
-        <a href="/get-involved" class="{% if pageName == 'get-involved' %}selected{% endif %}">{{ gettext("userbarGetInvolved") }}</a>
+        <a href="/{{ locale }}" class="{% if pageName == 'home' %}selected{% endif %}">{{ gettext("userbarGetStarted") }}</a>
+        <a href="/{{ locale }}/features" class="{% if pageName == 'features' %}selected{% endif %}">{{ gettext("userbarCoolFeatures") }}</a>
+        <a href="/{{ locale }}/get-involved" class="{% if pageName == 'get-involved' %}selected{% endif %}">{{ gettext("userbarGetInvolved") }}</a>
       </div>
     </div>
 


### PR DESCRIPTION
They were always going to `en-US` otherwise, even if you selected a different language on the homepage.