### PR TITLE
Don't crash on load when Thimble expects newer Bramble API

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,7 @@ module.exports = function( grunt ) {
             "bramble-editor": "editor/scripts/editor/js/bramble-editor",
             "sso-override": "editor/scripts/sso-override",
             "logger": "editor/scripts/logger",
+            "BrambleShim": "editor/scripts/bramble-shim",
             "jquery": "../node_modules/jquery/dist/jquery.min",
             "localized": "../node_modules/webmaker-i18n/localized",
             "uuid": "../node_modules/node-uuid/uuid",

--- a/public/editor/scripts/bramble-shim.js
+++ b/public/editor/scripts/bramble-shim.js
@@ -1,0 +1,55 @@
+/**
+ * Temporary Bramble API protection to deal with the case of Thimble and Bramble
+ * being out of sync (e.g., Service Worker Cache), and Thimble trying to use methods
+ * in Bramble that don't exist in the cached version of Bramble. We have code to deal
+ * with this, and will prompt the user to refresh, and get new a new API version;
+ * however, we'd like to avoid crashing first.  This shims all potential API methods
+ * that might cause us to crash, so we at least get to load fully, after which we'll
+ * show the refresh info.
+ *
+ * If you add some new API call to Bramble, add a shim here first so we always start up.
+ */
+
+define(function() {
+
+  function defaultFalse() {
+    return false;
+  }
+
+  function defaultTrue() {
+    return true;
+  }
+
+  function returnZero() {
+    return 0;
+  }
+
+  function noop() {}
+
+  function arg0WithCallback(callback) {
+    callback = callback || noop;
+    setTimeout(callback, 0);
+  }
+
+  function arg1WithCallback(arg0, callback) {
+    callback = callback || noop;
+    setTimeout(callback, 0);
+  }
+
+  // Add any missing functions we might need until the user updates their API.
+  return function shimAPI(bramble) {
+    bramble.getAllowJavaScript     = bramble.getAllowJavaScript || defaultTrue;
+    bramble.getAutocomplete        = bramble.getAutocomplete || defaultTrue;
+    bramble.getAutoCloseTags       = bramble.getAutoCloseTags || defaultTrue;
+    bramble.getAutoUpdate          = bramble.getAutoUpdate || defaultTrue;
+    bramble.getTotalProjectSize    = bramble.getTotalProjectSize || returnZero;
+    bramble.hasIndexFile           = bramble.hasIndexFile || defaultFalse;
+    bramble.getFileCount           = bramble.getFileCount || returnZero;
+
+    bramble.addCodeSnippet         = bramble.addCodeSnippet || arg1WithCallback;
+    bramble.configureAutoCloseTags = bramble.configureAutoCloseTags || arg1WithCallback;
+    bramble.openSVGasXML           = bramble.openSVGasXML || arg0WithCallback;
+    bramble.openSVGasImage         = bramble.openSVGasImage || arg0WithCallback;
+  };
+
+});

--- a/public/editor/scripts/bramble-shim.js
+++ b/public/editor/scripts/bramble-shim.js
@@ -8,19 +8,44 @@
  * show the refresh info.
  *
  * If you add some new API call to Bramble, add a shim here first so we always start up.
+ *
+ * NOTE: this shim deals with new code since:
+ * https://github.com/mozilla/brackets/commit/b8dfbc6a20c785437b0441839c3825df72e38dc0
+ *
+ * See https://github.com/mozilla/thimble.mozilla.org/pull/2097#issuecomment-301494035
+ * for API additons covered below.
  */
 
 define(function() {
 
+  var sentUpdatesAvailable = false;
+
+  function triggerUpdatesAvailable() {
+    // Since we've used a shimmed API call, we should trigger our Reload flow.
+    // The `updatesAvailable` event was introduced in the new API, so won't happen
+    // with this old API; however, if we've loaded Bramble, it will also have updated
+    // cache, and it should do the right thing when the user reloads.
+    if(sentUpdatesAvailable) {
+      return;
+    }
+
+    sentUpdatesAvailable = true;
+    console.log("[Thimble] Bramble API out of date, please reload your browser for updates");
+    Bramble.trigger("updatesAvailable");
+  }
+
   function defaultFalse() {
+    triggerUpdatesAvailable();
     return false;
   }
 
   function defaultTrue() {
+    triggerUpdatesAvailable();
     return true;
   }
 
   function returnZero() {
+    triggerUpdatesAvailable();
     return 0;
   }
 
@@ -29,27 +54,39 @@ define(function() {
   function arg0WithCallback(callback) {
     callback = callback || noop;
     setTimeout(callback, 0);
+    triggerUpdatesAvailable();
   }
 
   function arg1WithCallback(arg0, callback) {
-    callback = callback || noop;
-    setTimeout(callback, 0);
+    arg0WithCallback(callback);
   }
 
   // Add any missing functions we might need until the user updates their API.
-  return function shimAPI(bramble) {
-    bramble.getAllowJavaScript     = bramble.getAllowJavaScript || defaultTrue;
-    bramble.getAutocomplete        = bramble.getAutocomplete || defaultTrue;
-    bramble.getAutoCloseTags       = bramble.getAutoCloseTags || defaultTrue;
-    bramble.getAutoUpdate          = bramble.getAutoUpdate || defaultTrue;
-    bramble.getTotalProjectSize    = bramble.getTotalProjectSize || returnZero;
-    bramble.hasIndexFile           = bramble.hasIndexFile || defaultFalse;
-    bramble.getFileCount           = bramble.getFileCount || returnZero;
+  function shimAPI(bramble) {
+    // New API Getters
+    bramble.getAutocomplete        = bramble.getAutocomplete        || defaultTrue;
+    bramble.getAutoCloseTags       = bramble.getAutoCloseTags       || defaultTrue;
+    bramble.getAllowJavaScript     = bramble.getAllowJavaScript     || defaultTrue;
+    bramble.getAllowWhiteSpace     = bramble.getAllowWhiteSpace     || defaultFalse;
+    bramble.getAutoUpdate          = bramble.getAutoUpdate          || defaultTrue;
+    bramble.getOpenSVGasXML        = bramble.getOpenSVGasXML        || defaultFalse;
+    bramble.getTotalProjectSize    = bramble.getTotalProjectSize    || returnZero;
+    bramble.hasIndexFile           = bramble.hasIndexFile           || defaultTrue;
+    bramble.getFileCount           = bramble.getFileCount           || returnZero;
 
-    bramble.addCodeSnippet         = bramble.addCodeSnippet || arg1WithCallback;
+    // New API Methods
+    bramble.enableWhiteSpace       = bramble.enableWhiteSpace       || arg0WithCallback;
+    bramble.disableWhiteSpace      = bramble.disableWhiteSpace      || arg0WithCallback;
+    bramble.enableAutocomplete     = bramble.enableAutocomplete     || arg0WithCallback;
+    bramble.disableAutocomplete    = bramble.disableAutocomplete    || arg0WithCallback;
+    bramble.openSVGasXML           = bramble.openSVGasXML           || arg0WithCallback;
+    bramble.openSVGasImage         = bramble.openSVGasImage         || arg0WithCallback;
     bramble.configureAutoCloseTags = bramble.configureAutoCloseTags || arg1WithCallback;
-    bramble.openSVGasXML           = bramble.openSVGasXML || arg0WithCallback;
-    bramble.openSVGasImage         = bramble.openSVGasImage || arg0WithCallback;
+    bramble.addCodeSnippet         = bramble.addCodeSnippet         || arg1WithCallback;
+  };
+
+  return {
+    shimAPI: shimAPI
   };
 
 });

--- a/public/editor/scripts/bramble-shim.js
+++ b/public/editor/scripts/bramble-shim.js
@@ -83,7 +83,7 @@ define(function() {
     bramble.openSVGasImage         = bramble.openSVGasImage         || arg0WithCallback;
     bramble.configureAutoCloseTags = bramble.configureAutoCloseTags || arg1WithCallback;
     bramble.addCodeSnippet         = bramble.addCodeSnippet         || arg1WithCallback;
-  };
+  }
 
   return {
     shimAPI: shimAPI

--- a/public/editor/scripts/editor/js/bramble-editor.js
+++ b/public/editor/scripts/editor/js/bramble-editor.js
@@ -2,7 +2,8 @@ define(function(require) {
   var $ = require("jquery"),
       BrambleUIBridge = require("fc/bramble-ui-bridge"),
       FileSystemSync = require("fc/filesystem-sync"),
-      Project = require("project/project");
+      Project = require("project/project"),
+      BrambleShim = require("BrambleShim");
 
   var csrfToken = $("meta[name='csrf-token']").attr("content");
 
@@ -31,6 +32,10 @@ define(function(require) {
       });
 
       Bramble.once("ready", function(bramble) {
+        // Make sure we don't crash trying to access new APIs not in Bramble's API
+        // before we update the Service Worker cached version we're using.
+        BrambleShim.shimAPI(bramble);
+
         // For debugging, attach to window.
         window.bramble = bramble;
         BrambleUIBridge.init(bramble, csrfToken, options.appUrl);

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -10,6 +10,7 @@ require.config({
     "bowser": "/scripts/vendor/bowser",
     "sso-override": "../../sso-override",
     "logger": "../../logger",
+    "BrambleShim": "../../bramble-shim",
     "jquery": "/node_modules/jquery/dist/jquery.min",
     "localized": "/node_modules/webmaker-i18n/localized",
     "uuid": "/node_modules/node-uuid/uuid",


### PR DESCRIPTION
I have a few bugs in Thimble and Brackets (e.g., #1931) where I'm worrying about startup issues when the Bramble API we have in the Service Worker cache is not the same as what Thimble expects, specifically, when Thimble tries to use some new API call that isn't there in Bramble, and it just crashes and halts startup.  We've improved this a bunch with a couple of fixes to show "reload" buttons; but it still means we might crash, and a user who used to have a working Thimble suddenly doesn't.  That's what I'm most worried about with us launching all this new code.

This PR tries to mitigate that risk by providing default, shimmed versions of new APIs.  We will still want users to update, or some new features won't work fully; but at least we won't crash on startup, and we'll show the new "Reload to get updates" UX.

Eventually I want to get to a place where we don't need this at all; but until then, I think this is a big improvement.  I need to confirm that I've got all the new APIs since we last pushed to prod.  I'll do some more work on this tomorrow morning, when I can confirm what's on prod now.

NOTE: there are other APIs on Bramble for which I'm not providing a fallback implementation.  I'm only focused on the ones that are new, and are used in was that might cause us to crash.