### PR TITLE
Updated features page layout to accommodate long descriptions.

### DIFF
--- a/public/homepage/stylesheets/features.less
+++ b/public/homepage/stylesheets/features.less
@@ -17,8 +17,8 @@
 // List of features
 
 .feature-list {
-  overflow: auto;
-  margin-right: -60px;
+  display: flex;
+  flex-wrap: wrap;
 
   .key {
     background: #333;
@@ -34,8 +34,6 @@
     margin-bottom: 40px;
     padding-bottom: 5px;
     width: 50%;
-    float: left;
-    min-height: 450px;
     box-sizing: border-box;
     padding-right: 60px;
 


### PR DESCRIPTION
Layout now accommodates very long feature descriptions without breaking the layout, as seen below. Tested in FF, Chrome & IE 11 via Browser Stack.

![image](https://cloud.githubusercontent.com/assets/25212/26070920/36049864-395b-11e7-9f9f-4d3955f02ae0.png)

Fixes #2098
