### PR TITLE
Expire session on 500s, only keep cookies for 1 week

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -26,6 +26,7 @@ let cssAssets = path.join(require("os").tmpDir(), "mozilla.webmaker.org");
 let editor = url.parse(env.get("BRAMBLE_URI"));
 let editorHost = `${editor.protocol}//${editor.host}`;
 let maxCacheAge = { maxAge: "1d" };
+let maxAge1Week = 7 * 24 * 3600000;
 let homepageVideoLink = "https://www.youtube.com/embed/JecFOjD9I3k";
 
 /*
@@ -42,7 +43,6 @@ server.locals.node_path = "node_modules";
  */
 templatize(server, [ "views" ]);
 
-
 /**
  * Request/Response configuration
  */
@@ -57,7 +57,7 @@ requests.disableHeaders([ "x-powered-by" ])
   key: "mozillaThimble",
   secret: env.get("SESSION_SECRET"),
   cookie: {
-    expires: false,
+    maxAge: maxAge1Week,
     secure: env.get("FORCE_SSL")
   },
   proxy: true

--- a/server/lib/http-error.js
+++ b/server/lib/http-error.js
@@ -29,6 +29,11 @@ class HttpError {
         response.send(`${userFriendlyError.statusMessage}: ${userFriendlyError.message}`);
       },
       html() {
+        // If we get a 500, clear cookies so that we don't wedge user's browser
+        // with corrupt/expired cookie info, and for them to clear via browser.
+        if(statusCode === 500) {
+          request.session = null;
+        }
         response.render("error.html", userFriendlyError);
       },
       json() {


### PR DESCRIPTION
Changes our `mozillaThimble` cookie to expire after 1 week vs. never, and forces sessions to get destroyed when we hit 500s, in the hopes of avoiding the case where user cookies are blocking a request from proceeding.