### PR TITLE
move maxAge into the session options

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -56,8 +56,8 @@ requests.disableHeaders([ "x-powered-by" ])
 .sessions({
   key: "mozillaThimble",
   secret: env.get("SESSION_SECRET"),
+  maxAge: maxAge1Week,
   cookie: {
-    maxAge: maxAge1Week,
     secure: env.get("FORCE_SSL")
   },
   proxy: true


### PR DESCRIPTION
this binds the maxAge to the express session, rather than the cookie parser