### PR TITLE
Pass all necessary variables to error.html template for 404s

### DIFF
--- a/server/lib/http-error.js
+++ b/server/lib/http-error.js
@@ -2,28 +2,34 @@
 
 const Nunjucks = require("nunjucks");
 
+function toUserFriendlyError(error, request, statusCode) {
+  //jshint unused:vars
+  const localeInfo = request.localeInfo;
+  const locale = (localeInfo && localeInfo.locale) || "en-US";
+  let statusMessage = statusCode;
+  const statusMessageKey = HttpError.getStatusMessageKey(statusCode);
+
+  if(statusMessageKey) {
+    statusMessage = Nunjucks.renderString(
+      request.gettext(statusMessageKey, locale),
+      { httpStatusCode: statusCode }
+    );
+  }
+
+  return {
+    statusMessage,
+    status: statusCode,
+    message: error ? (error.userMessage || error) : statusMessage,
+    localeInfo,
+    locale
+  };
+}
+
 class HttpError {
   static generic(error, request, response, next) {
     //jshint unused:vars
-    const localeInfo = request.localeInfo;
-    const locale = (localeInfo && localeInfo.locale) || "en-US";
-    const statusCode = response.statusCode || 500;
-    let statusMessage = statusCode;
-    const statusMessageKey = HttpError.getStatusMessageKey(statusCode);
-
-    if(statusMessageKey) {
-      statusMessage = Nunjucks.renderString(
-        request.gettext(statusMessageKey, locale),
-        { httpStatusCode: statusCode }
-      );
-    }
-
-    const userFriendlyError = {
-      statusMessage,
-      status: statusCode,
-      message: error.userMessage || error,
-      localeInfo
-    };
+    let statusCode = response.statusCode || 500;
+    let userFriendlyError = toUserFriendlyError(error, request, statusCode);
 
     response.format({
       text() {
@@ -50,8 +56,10 @@ class HttpError {
 
   static notFound(request, response, next) {
     //jshint unused:vars
+    let userFriendlyError = toUserFriendlyError(null, request, 404);
+
     response.status(404);
-    response.render("error.html", { status: 404 });
+    response.render("error.html", userFriendlyError);
   }
 
   static getStatusMessageKey(statusCode) {


### PR DESCRIPTION
I notice that we aren't passing all the necessary variables to the `error.html` template when we show a 404 error vs. what we do on 500s.