### PR TITLE
Temporary token assert code to figure out what's breaking on prod

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -93,3 +93,5 @@ export HOMEWORK_EXCUSE_GENERATOR_KIT_URL="https://d157rqmxrxj6ey.cloudfront.net/
 export SIX_WORD_SUMMER_REMIX_URL="https://thimble.mozilla.org/{{ locale }}/projects/2500/remix"
 export SIX_WORD_SUMMER_KIT_URL="https://d157rqmxrxj6ey.cloudfront.net/mozillalearning/11704/"
 
+# Debug flag for logging asserts on user token, see https://github.com/mozilla/thimble.mozilla.org/issues/2161
+export ASSERT_TOKEN=false

--- a/server/lib/middleware.js
+++ b/server/lib/middleware.js
@@ -85,16 +85,18 @@ module.exports = function middlewareConstructor(config) {
       let token = req.user.token = cryptr.decrypt(req.session.token);
 
       if(ASSERT_TOKEN) {
-        // We expect a token of the form '16d4c4d2fa4d6e4aa6b1b5c6a115ad44fd271dd98204f2008bf5efbba5a56dec'
+        // We expect a 64 character HEX string for the token, for example:
+        // '16d4c4d2fa4d6e4aa6b1b5c6a115ad44fd271dd98204f2008bf5efbba5a56dec'
         let tokenType = typeof token;
         if(!token) {
           console.log("ASSERT_TOKEN FAILED: Expected token to exist");
         } else {
           if(tokenType !== "string") {
             console.log("ASSERT_TOKEN FAILED: Expected token type to be String, instead got: " + tokenType);
-          }
-          if(!/^[a-z0-9]+$/.test(token)) {
-            console.log("ASSERT_TOKEN FAILED: Expected token to only have chars a-z, 0-9. Also got: '" +  token.replace(/[a-z0-9]/g, ' ') + "'");
+          } else {
+            if(!/^[a-z0-9]{64}$/.test(token)) {
+              console.log("ASSERT_TOKEN FAILED: Expected token to only have chars a-z, 0-9. Also got: '" +  token.replace(/[a-z0-9]/g, ' ') + "'");
+            }
           }
         }
       }

--- a/server/lib/middleware.js
+++ b/server/lib/middleware.js
@@ -87,9 +87,16 @@ module.exports = function middlewareConstructor(config) {
       if(ASSERT_TOKEN) {
         // We expect a token of the form '16d4c4d2fa4d6e4aa6b1b5c6a115ad44fd271dd98204f2008bf5efbba5a56dec'
         let tokenType = typeof token;
-        console.assert(token, "Expected token to exist");
-        console.assert(tokenType === "string", "Expected token type to be String, got %s", tokenType);
-        console.assert(/^[a-z0-9]+$/.test(token), "Expected token to only have chars a-z, 0-9. Also got %s", token.replace(/[a-z0-9]/g, ' '));
+        if(!token) {
+          console.log("ASSERT_TOKEN FAILED: Expected token to exist");
+        } else {
+          if(tokenType !== "string") {
+            console.log("ASSERT_TOKEN FAILED: Expected token type to be String, instead got: " + tokenType);
+          }
+          if(!/^[a-z0-9]+$/.test(token)) {
+            console.log("ASSERT_TOKEN FAILED: Expected token to only have chars a-z, 0-9. Also got: '" +  token.replace(/[a-z0-9]/g, ' ') + "'");
+          }
+        }
       }
 
       next();


### PR DESCRIPTION
This adds the ability to assert that a user's session token exists, is a string, and is of the proper form.  If those aren't true, we log it.  I am not logging the actual token, only the characters that are outside what we expect.

cc @cadecairos, @Pomax 