### PR TITLE
Duplicate Export to .zip feature to avoid confusing users, fixes #2115

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-menus.js
+++ b/public/editor/scripts/editor/js/fc/bramble-menus.js
@@ -315,6 +315,7 @@ define(function(require) {
     var $addJs = $("#filetree-pane-nav-add-js");
     var $addUpload = $("#filetree-pane-nav-add-upload");
     var $addTutorial = $("#filetree-pane-nav-add-tutorial");
+    var $downloadZip = $("#filetree-pane-nav-export-project-zip");
 
     // Add File button and popup menu
     var menu = PopupMenu.createWithOffset("#filetree-pane-nav-add", "#filetree-pane-nav-add-menu");
@@ -394,6 +395,13 @@ define(function(require) {
       menu.close();
       bramble.showUploadFilesDialog();
       analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Upload File Dialog Shown"});
+    });
+
+    $downloadZip.click(function() {
+      menu.close();
+      bramble.export();
+      analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "Export ZIP"});
+      return false;
     });
 
     // We hide the add tutorial button if a tutorial exists

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -160,7 +160,7 @@ define(function(require) {
       });
     });
 
-    $("#filetree-pane-nav-export-project-zip").click(function() {
+    $("#export-project-zip").click(function() {
       bramble.export();
       analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "Export ZIP"});
       return false;

--- a/views/editor/userbar.html
+++ b/views/editor/userbar.html
@@ -82,7 +82,7 @@
                 <li>
                   <a href="#" id="export-project-zip" target="_self">
                     <img src="/img/icon/download-cloud.svg">
-                    {{ gettext("exportProjectLink") }}
+                    {{ gettext("downloadProjectLink") }}
                   </a>
                 </li>
                 <li>

--- a/views/editor/userbar.html
+++ b/views/editor/userbar.html
@@ -80,6 +80,12 @@
                   </a>
                 </li>
                 <li>
+                  <a href="#" id="export-project-zip" target="_self">
+                    <img src="/img/icon/download-cloud.svg">
+                    {{ gettext("exportProjectLink") }}
+                  </a>
+                </li>
+                <li>
                   <a href="{{ logoutURL }}" id="logout-link" target="_self">
                     <img src="/img/icon/sign-out.svg" />
                     {{ gettext("signOutLink") }}


### PR DESCRIPTION
This undoes some of what we did in https://github.com/mozilla/thimble.mozilla.org/commit/adf9a5f79f7828e2b025cc673c412dff823d2928 in order to duplicate the "Export .zip" feature, since users are confused by us moving it, and thinking we killed it off.  I think it's better to have it in both places.  I've also fixed the bug where we don't close the popup menu when we download the zip #2115.

Later in #2162 we might do something different again.  This is a stop-gap until then.