### PR TITLE
Fix #2121: Add missing l10n string for console hint text

### DIFF
--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -222,3 +222,5 @@ CONSOLE_CLEAR_TOOLTIP=Clear the Console
 CONSOLE_CLOSE_TOOLTIP=Close the Console
 # When a user logs an empty string to the console, this will show instead of nothing
 CONSOLE_EMPTY_STRING=Empty String
+# Text that shows up when the console is empty with instructions on how to use it
+CONSOLE_HELPTEXT=To use the console, add <code>console.log("Hello World!");</code> to your JavasScript file.


### PR DESCRIPTION
When we did https://github.com/mozilla/brackets/commit/413d7ce321b78e30cbf6124b0087ee15dfb41319 in Brackets, we forgot to land the string here.  This adds it.