### PR TITLE
Return proper object type for bramble.getAutoCloseTags() shim, don't crash

### DIFF
--- a/public/editor/scripts/bramble-shim.js
+++ b/public/editor/scripts/bramble-shim.js
@@ -73,6 +73,7 @@ define(function() {
   function shimAPI(bramble) {
     // New API Getters
     bramble.getAutocomplete        = bramble.getAutocomplete        || defaultTrue;
+    bramble.getAutoCloseTags       = bramble.getAutoCloseTags       || getAutoCloseTagsDefault;
     bramble.getAllowJavaScript     = bramble.getAllowJavaScript     || defaultTrue;
     bramble.getAllowWhiteSpace     = bramble.getAllowWhiteSpace     || defaultFalse;
     bramble.getAutoUpdate          = bramble.getAutoUpdate          || defaultTrue;
@@ -90,12 +91,6 @@ define(function() {
     bramble.openSVGasImage         = bramble.openSVGasImage         || arg0WithCallback;
     bramble.configureAutoCloseTags = bramble.configureAutoCloseTags || arg1WithCallback;
     bramble.addCodeSnippet         = bramble.addCodeSnippet         || arg1WithCallback;
-
-    // bramble.getAutoCloseTags is different, since return type changed too (boolean to object)
-    if (bramble.getAutoCloseTags && typeof bramble.getAutoCloseTags !== "object") {
-      bramble.getAutoCloseTags = getAutoCloseTagsDefault;
-    }
-
   }
 
   return {

--- a/public/editor/scripts/bramble-shim.js
+++ b/public/editor/scripts/bramble-shim.js
@@ -49,6 +49,14 @@ define(function() {
     return 0;
   }
 
+  function getAutoCloseTagsDefault() {
+    return {
+      whenClosing: true,
+      whenOpening: true,
+      indentTags: []
+    };
+  }
+
   function noop() {}
 
   function arg0WithCallback(callback) {
@@ -65,7 +73,7 @@ define(function() {
   function shimAPI(bramble) {
     // New API Getters
     bramble.getAutocomplete        = bramble.getAutocomplete        || defaultTrue;
-    bramble.getAutoCloseTags       = bramble.getAutoCloseTags       || defaultTrue;
+    bramble.getAutoCloseTags       = bramble.getAutoCloseTags       || getAutoCloseTagsDefault;
     bramble.getAllowJavaScript     = bramble.getAllowJavaScript     || defaultTrue;
     bramble.getAllowWhiteSpace     = bramble.getAllowWhiteSpace     || defaultFalse;
     bramble.getAutoUpdate          = bramble.getAutoUpdate          || defaultTrue;

--- a/public/editor/scripts/bramble-shim.js
+++ b/public/editor/scripts/bramble-shim.js
@@ -73,7 +73,6 @@ define(function() {
   function shimAPI(bramble) {
     // New API Getters
     bramble.getAutocomplete        = bramble.getAutocomplete        || defaultTrue;
-    bramble.getAutoCloseTags       = bramble.getAutoCloseTags       || getAutoCloseTagsDefault;
     bramble.getAllowJavaScript     = bramble.getAllowJavaScript     || defaultTrue;
     bramble.getAllowWhiteSpace     = bramble.getAllowWhiteSpace     || defaultFalse;
     bramble.getAutoUpdate          = bramble.getAutoUpdate          || defaultTrue;
@@ -91,6 +90,12 @@ define(function() {
     bramble.openSVGasImage         = bramble.openSVGasImage         || arg0WithCallback;
     bramble.configureAutoCloseTags = bramble.configureAutoCloseTags || arg1WithCallback;
     bramble.addCodeSnippet         = bramble.addCodeSnippet         || arg1WithCallback;
+
+    // bramble.getAutoCloseTags is different, since return type changed too (boolean to object)
+    if (bramble.getAutoCloseTags && typeof bramble.getAutoCloseTags !== "object") {
+      bramble.getAutoCloseTags = getAutoCloseTagsDefault;
+    }
+
   }
 
   return {

--- a/public/editor/scripts/editor/js/fc/bramble-menus.js
+++ b/public/editor/scripts/editor/js/fc/bramble-menus.js
@@ -228,7 +228,8 @@ define(function(require) {
     });
 
     //set the AutoCloseTags toggle to reflect whether auto-close tags is enabled or disabled
-    if(bramble.getAutoCloseTags().whenClosing) {
+    var autoCloseTags = bramble.getAutoCloseTags() || {};
+    if(autoCloseTags.whenClosing) {
       $("#auto-tags-toggle").addClass("switch-enabled");
     } else {
       $("#auto-tags-toggle").removeClass("switch-enabled");


### PR DESCRIPTION
Fix for crash reported by user:

![image](https://cloud.githubusercontent.com/assets/427398/26217533/c16082b6-3bd5-11e7-84d8-1e54b3467e17.png)

I was returning the wrong type in the BrambleShim code.  The real answer is for the user to update to the new Bramble API, but this will stop us from crashing, and let the "Reload Now" flow work.