### PR TITLE
Fix #2072 - make it possible to add new folders from Thimble

### DIFF
--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -66,6 +66,10 @@ navHTMLFile=Add HTML file
 navCSSFile=Add CSS file
 navJavascriptFile=Add JavaScript file
 navTutorialFile=Add a Tutorial
+# Tooltip shown for adding a new folder in the files menu
+navAddFolderTitle=Add a new Folder
+# Text to display in the files menu for adding a new folder
+navAddFolder=Add Folder
 navUploadFile=Upload a file…
 navEditor=EDITOR
 navUndo=Undo

--- a/public/editor/scripts/editor/js/fc/bramble-menus.js
+++ b/public/editor/scripts/editor/js/fc/bramble-menus.js
@@ -315,6 +315,7 @@ define(function(require) {
     var $addCss = $("#filetree-pane-nav-add-css");
     var $addJs = $("#filetree-pane-nav-add-js");
     var $addUpload = $("#filetree-pane-nav-add-upload");
+    var $addFolder = $("#filetree-pane-nav-add-folder");
     var $addTutorial = $("#filetree-pane-nav-add-tutorial");
     var $downloadZip = $("#filetree-pane-nav-export-project-zip");
 
@@ -390,6 +391,12 @@ define(function(require) {
         }
         analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Add File", label : "Tutorial" });
       });
+    });
+
+    $addFolder.click(function() {
+      menu.close();
+      bramble.addNewFolder();
+      analytics.event({ category : analytics.eventCategories.EDITOR_UI, action : "Add New Folder"});
     });
 
     $addUpload.click(function() {

--- a/views/editor/nav-options.html
+++ b/views/editor/nav-options.html
@@ -18,6 +18,7 @@
             <li title="{{ gettext("navCSSTitle") }}" id="filetree-pane-nav-add-css"><span>{{ gettext("navCSSFile") }}</span>
             <li title="{{ gettext("navJavascriptTitle") }}" id="filetree-pane-nav-add-js"><span>{{ gettext("navJavascriptFile") }}</span>
             <li title="{{ gettext("navTutorial") }}" id="filetree-pane-nav-add-tutorial"><span>{{ gettext("navTutorialFile") }}</span>
+            <li title="{{ gettext("navAddFolderTitle") }}" id="filetree-pane-nav-add-folder"><span>{{ gettext("navAddFolder") }}</span>
             <li title="{{ gettext("navUploadTitle") }}" id="filetree-pane-nav-add-upload"><span>{{ gettext("navUploadFile") }}</span>
             <li title="{{ gettext("downloadProjectLink") }}" id="filetree-pane-nav-export-project-zip" class="top-border"><span>{{ gettext("downloadProjectLink") }}</span>
           </ul>


### PR DESCRIPTION
This adds a new menu option above the file tree to enable adding folders.

I also wrote https://github.com/mozilla/brackets/pull/767 on the Brackets side to fix an issue in the naming of our commands, and we should land that first.