### PR TITLE
Expand GA analytics to include timing and exception tracking

### DIFF
--- a/public/editor/scripts/analytics.js
+++ b/public/editor/scripts/analytics.js
@@ -72,36 +72,35 @@
 
   // Exception Tracking: https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions
   function exception(error, fatal) {
-    var eventOptions = {
-      "hitType": "exception"
-    };
+    var eventOptions = {};
 
     if(!error) {
       warn("Expected `error` arg.");
       return;
     }
-    eventOptions.exDescription = error.message ? error.message : error;
-    eventOptions.exFatal = fatal === true;
+    eventOptions["exDescription"] = error.message ? error.message : error;
+    if(fatal === true) {
+      eventOptions["exFatal"] = true;
+    }
 
-    gaSend(eventOptions);
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#exception
+    gaSend("exception", eventOptions);
   }
 
   // User Timings: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-timings
   function timing(options) {
     options = options || {};
-    var eventOptions = {
-      "hitType": "timing"
-    };
+    var eventOptions = {};
 
     // Timing Category
-    eventOptions.timingCategory = options.category || "Uncategorized";
+    eventOptions["timingCategory"] = options.category || "Uncategorized";
 
     // Timing Var
     if(!options.var) {
       warn("Expected `var` arg.");
       return;
     }
-    eventOptions.timingVar = options.var;
+    eventOptions["timingVar"] = options.var;
 
     // Timing Value
     if(options.value || options.value === 0) {
@@ -110,11 +109,11 @@
         return;
       }
       // Force value to int
-      eventOptions.timingValue = options.value|0;
+      eventOptions["timingValue"] = options.value|0;
     } else {
       // If now value is given, assume we want to try to measure time since page load
       if(window.performance) {
-        eventOptions.timingValue = Math.round(window.performance.now());
+        eventOptions["timingValue"] = Math.round(window.performance.now());
       } else {
         warn("Expected `value` arg to be a Number.");
         return;
@@ -122,19 +121,20 @@
     }
 
     if(options.label) {
-      eventOptions.timingLabel = trim(options.label);
+      eventOptions["timingLabel"] = trim(options.label);
     }
+
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#timing
+    gaSend("timing", eventOptions);
   }
 
   // Event Tracking: https://developers.google.com/analytics/devguides/collection/analyticsjs/events
   function event(options) {
     options = options || {};
-    var eventOptions = {
-      "hitType": "event"
-    };
+    var eventOptions = {};
 
     // Event Category
-    eventOptions.eventCategory = options.category || "Uncategorized";
+    eventOptions["eventCategory"] = options.category || "Uncategorized";
 
     // Event Action
     if(!options.action) {
@@ -145,7 +145,7 @@
       warn("`action` arg looks like an email address, redacting.");
       options.action = _redacted;
     }
-    eventOptions.eventAction = toTitleCase(options.action);
+    eventOptions["eventAction"] = toTitleCase(options.action);
 
     // Event Label
     if(options.label) {
@@ -156,7 +156,7 @@
           warn("`label` arg looks like an email address, redacting.");
           options.label = _redacted;
         }
-        eventOptions.eventLabel = trim(options.label);
+        eventOptions["eventLabel"] = trim(options.label);
       }
     }
 
@@ -166,7 +166,7 @@
         warn("Expected `value` arg to be a Number.");
       } else {
         // Force value to int
-        eventOptions.eventValue = options.value|0;
+        eventOptions["eventValue"] = options.value|0;
       }
     }
 
@@ -176,16 +176,17 @@
       if(typeof options.nonInteraction !== "boolean") {
         warn("Expected `noninteraction` arg to be a Boolean.");
       } else {
-        eventOptions.nonInteraction = options.nonInteraction === true;
+        eventOptions["nonInteraction"] = options.nonInteraction === true;
       }
     }
 
-    gaSend(eventOptions);
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#events
+    gaSend("event", eventOptions);
   }
 
-  function gaSend(eventOptions) {
+  function gaSend(hitType, eventOptions) {
     if(typeof ga === "function") {
-      ga('send', eventOptions);
+      ga("send", hitType, eventOptions);
     }
   }
 
@@ -218,10 +219,9 @@
       // Transform the argument array to match the expected call signature for ga():
       // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference
       var fieldObject = {
-        'hitType': 'pageview',
         'page': options.virtualPagePath
       };
-      gaSend(fieldObject);
+      gaSend("pageview", fieldObject);
     }
   }
 

--- a/public/editor/scripts/analytics.js
+++ b/public/editor/scripts/analytics.js
@@ -104,7 +104,7 @@
 
     // Timing Value
     if(options.value || options.value === 0) {
-      if(typeof value !== "number") {
+      if(typeof options.value !== "number") {
         warn("Expected `value` arg to be a Number.");
         return;
       }
@@ -115,7 +115,7 @@
       if(window.performance) {
         eventOptions["timingValue"] = Math.round(window.performance.now());
       } else {
-        warn("Expected `value` arg to be a Number.");
+        warn("Browser doesn't support window.performance, expected explicit `value` arg to be a Number.");
         return;
       }
     }

--- a/public/editor/scripts/editor/js/bramble-editor.js
+++ b/public/editor/scripts/editor/js/bramble-editor.js
@@ -3,7 +3,8 @@ define(function(require) {
       BrambleUIBridge = require("fc/bramble-ui-bridge"),
       FileSystemSync = require("fc/filesystem-sync"),
       Project = require("project/project"),
-      BrambleShim = require("BrambleShim");
+      BrambleShim = require("BrambleShim"),
+      analytics = require("analytics");
 
   var csrfToken = $("meta[name='csrf-token']").attr("content");
 
@@ -23,6 +24,8 @@ define(function(require) {
         if(err) {
           console.error("[Thimble Error]", err);
           $("#spinner-container").addClass("loading-error");
+          analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Project loading error (Green screen)" });
+          analytics.exception(err, true);
           return;
         }
 
@@ -32,6 +35,8 @@ define(function(require) {
       });
 
       Bramble.once("ready", function(bramble) {
+        analytics.timing({ category: analytics.timingCategories.BRAMBLE, var: "ready Event"});
+
         // Make sure we don't crash trying to access new APIs not in Bramble's API
         // before we update the Service Worker cached version we're using.
         BrambleShim.shimAPI(bramble);

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -8,6 +8,7 @@ define(function(require) {
   var FileSystemSync = require("fc/filesystem-sync");
   var Project = require("project/project");
   var analytics = require("analytics");
+  var Startup = require("fc/startup");
   var Path = Bramble.Filer.Path;
 
   var _escKeyHandler;
@@ -443,9 +444,7 @@ define(function(require) {
       BrambleMenus.refreshSnippets(Path.extname(data.filename).substr(1).toLowerCase());
     });
 
-    $("#spinner-container").fadeOut();
-    analytics.timing({ category: analytics.timingCategories.THIMBLE, var: "Editor UI Usable" });
-
+    Startup.finish();
     adaptLayout();
   }
 

--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -444,6 +444,8 @@ define(function(require) {
     });
 
     $("#spinner-container").fadeOut();
+    analytics.timing({ category: analytics.timingCategories.THIMBLE, var: "Editor UI Usable" });
+
     adaptLayout();
   }
 

--- a/public/editor/scripts/editor/js/fc/startup.js
+++ b/public/editor/scripts/editor/js/fc/startup.js
@@ -1,0 +1,91 @@
+/**
+ * Various startup logic related to showing/clearing loading UI, analytics, and errors.
+ */
+
+define(function(require) {
+  var $ = require("jquery");
+  var bowser = require("bowser");
+  var analytics = require("analytics");
+
+  // How long to wait until we show the "Slow loading..." UI
+  var errorMessageTimeoutMS = 10000;
+  var errorMessageTimeout;
+
+  function refreshClicked() {
+    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Refresh button clicked" });
+    window.location.reload(true);
+  }
+
+  function showLoadingErrorMessage() {
+    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Project loading slowly (Green screen)" });
+
+    $("#spinner-container .taking-too-long").addClass("visible");
+    $("button.refresh-browser").on("click", refreshClicked);
+  }
+
+  function onBrambleError(err) {
+    console.error("[Bramble Error] error loading Bramble", err);
+    $("#spinner-container").addClass("loading-error");
+    $("button.refresh-browser").on("click", refreshClicked);
+    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Editor loading error (Black Screen)" });
+    analytics.exception(err, true);
+  }
+
+  function showUpdatesAvailableRefreshAlert(){
+    console.log("Thimble has updates - please refresh your browser to get the latest changes.");
+    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Updates available UI shown" });
+    $("button.refresh-browser").on("click", refreshClicked);
+    $("body").addClass("has-alert-bar");
+    $("#serviceworker-warning").removeClass("hide");
+  }
+
+  function init(startFn) {
+    // Warn users of unsupported browsers that they can try something newer,
+    // specifically anything before IE 11 or Safari 8.
+    if((bowser.msie && bowser.version < 11) || (bowser.safari && bowser.version < 8)) {
+      $("#browser-support-warning").removeClass("hide");
+      analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Browser version warning shown" });
+
+      $(".let-me-in").on("click", function() {
+        analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Browser version warning dismissed" });
+        $("#browser-support-warning").fadeOut();
+        return;
+      });
+    }
+
+    // If Bramble fails to load (some browser loading issues cause it to fail),
+    // error out now, since we won't get to Bramble.on('error', ...)
+    if(!window.Bramble) {
+      onBrambleError(new Error("Unable to load Bramble editor in this browser"));
+      return;
+    }
+
+    // Listen for startup errors on Bramble
+    Bramble.once("error", onBrambleError);
+
+    // Listen for update events from Bramble's service worker
+    Bramble.once("updatesAvailable", showUpdatesAvailableRefreshAlert);
+
+    // Start a timer so we can warn if the editor hangs during starup
+    errorMessageTimeout = window.setTimeout(showLoadingErrorMessage, errorMessageTimeoutMS);
+
+    startFn();
+  }
+
+  function finish() {
+    if(errorMessageTimeout) {
+      window.clearTimeout(errorMessageTimeout);
+    }
+
+    // Once startup is done, we won't get errors from Bramble again.
+    Bramble.off("error", onBrambleError);
+
+    $("#spinner-container").fadeOut();
+    analytics.timing({ category: analytics.timingCategories.THIMBLE, var: "Startup Complete. Editor UI Usable" });
+  }
+
+  return {
+    init: init,
+    finish: finish
+  };
+});

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -27,62 +27,9 @@ require.config({
   }
 });
 
-require(["jquery", "bowser", "analytics"], function($, bowser, analytics) {
-  // Warn users of unsupported browsers that they can try something newer,
-  // specifically anything before IE 11 or Safari 8.
-  if((bowser.msie && bowser.version < 11) || (bowser.safari && bowser.version < 8)) {
-    $("#browser-support-warning").removeClass("hide");
+require(["fc/startup"], function(Startup) {
 
-    $(".let-me-in").on("click", function() {
-      $("#browser-support-warning").fadeOut();
-      return false;
-    });
-  }
-
-  $("button.refresh-browser").on("click",function(){
-    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Refresh button clicked" });
-    window.location.reload(true);
-  });
-
-  function onError(err) {
-    console.error("[Bramble Error]", err);
-    $("#spinner-container").addClass("loading-error");
-    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Editor loading error (Black Screen)" });
-    analytics.exception(err, true);
-  }
-
-  // If Bramble fails to load (some browser loading issues cause it to fail),
-  // error out now, since we won't get to Bramble.on('error', ...)
-  if(!window.Bramble) {
-    onError(new Error("Unable to load Bramble editor in this browser"));
-    return;
-  }
-
-  Bramble.once("error", onError);
-
-  var errorMessageTimeoutMS = 15000;
-
-  setTimeout(function(){
-    showLoadingErrorMessage();
-  }, errorMessageTimeoutMS);
-
-  function showLoadingErrorMessage(){
-    $("#spinner-container .taking-too-long").addClass("visible");
-    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Project loading slowly (Green screen)" });
-  }
-
-  Bramble.once("updatesAvailable", function() {
-    showRefreshAlert();
-  });
-
-  function showRefreshAlert(){
-    console.log("Thimble has updates - please refresh your browser to get the latest changes.");
-    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Updates available UI shown" });
-    $("body").addClass("has-alert-bar");
-    $("#serviceworker-warning").removeClass("hide");
-  }
-
-  function init(BrambleEditor, Project, SSOOverride, ProjectRenameUtility) {
+  function init(BrambleEditor, Project, SSOOverride, ProjectRenameUtility, analytics) {
     var thimbleScript = document.getElementById("thimble-script");
     var appUrl = thimbleScript.getAttribute("data-app-url");
     var projectDetails = thimbleScript.getAttribute("data-project-details");
@@ -112,5 +59,7 @@ require(["jquery", "bowser", "analytics"], function($, bowser, analytics) {
     });
   }
 
-  require(["bramble-editor", "project/project", "sso-override", "fc/project-rename"], init);
+  Startup.init(function start() {
+    require(["bramble-editor", "project/project", "sso-override", "fc/project-rename", "analytics"], init);
+  });
 });

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -47,10 +47,8 @@ require(["jquery", "bowser", "analytics"], function($, bowser, analytics) {
   function onError(err) {
     console.error("[Bramble Error]", err);
     $("#spinner-container").addClass("loading-error");
-    if(!err) {
-      err = "Error not defined";
-    }
-    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Editor loading error (Black Screen)", label : err.toString() });
+    analytics.event({ category : analytics.eventCategories.TROUBLESHOOTING, action : "Editor loading error (Black Screen)" });
+    analytics.exception(err, true);
   }
 
   // If Bramble fails to load (some browser loading issues cause it to fail),
@@ -96,6 +94,7 @@ require(["jquery", "bowser", "analytics"], function($, bowser, analytics) {
     Project.init(projectDetails, appUrl, function(err) {
       if (err) {
         console.error("[Bramble] Failed to load Project state, with", err);
+        analytics.exception(err, true);
       }
 
       // Initialize the name UI for an anonymous project


### PR DESCRIPTION
I notice that we can include timing and exception analytics in GA along with event categories.  I've expanded the API and added some new tracking code to help us see what's happening.

Fixes #2212