### PR TITLE
Fix #2163 - Missing locale variable breaks links on 404 page

### DIFF
--- a/views/error.html
+++ b/views/error.html
@@ -1,5 +1,7 @@
+{% set locale = localeInfo.lang %}
+{% set localeDir = localeInfo.locale %}
 <!DOCTYPE html>
-<html lang="{{ localeInfo.lang }}" dir="{{ localeInfo.direction }}">
+<html lang="{{ locale }}" dir="{{ localeInfo.direction }}">
   <head>
     <meta charset="utf-8">
     <title>{{ gettext("errorSomethingWentWrong") }}</title>
@@ -67,7 +69,7 @@
       </div>
     </section>
 
-    <script src="/{{ localeInfo.locale }}/error/scripts/main.js"></script>
+    <script src="/{{ localeDir }}/error/scripts/main.js"></script>
 
     {% include 'footer.html' %}
   </body>


### PR DESCRIPTION
This should fix the logo link and also cleans up the code a bit.