### PR TITLE
Removes false positive "slow project loading" google event.

### DIFF
--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -62,11 +62,11 @@ require(["jquery", "bowser", "analytics"], function($, bowser, analytics) {
 
   Bramble.once("error", onError);
 
-  var errorMessageTimeoutMS = 15000;
+  var slowLoadingTimeoutMS = 15000;
 
-  setTimeout(function(){
+  var slowLoadingTimeout = setTimeout(function(){
     showLoadingErrorMessage();
-  }, errorMessageTimeoutMS);
+  }, slowLoadingTimeoutMS);
 
   function showLoadingErrorMessage(){
     $("#spinner-container .taking-too-long").addClass("visible");
@@ -89,6 +89,7 @@ require(["jquery", "bowser", "analytics"], function($, bowser, analytics) {
     var appUrl = thimbleScript.getAttribute("data-app-url");
     var projectDetails = thimbleScript.getAttribute("data-project-details");
     var editorUrl = thimbleScript.getAttribute("data-editor-url");
+    clearTimeout(slowLoadingTimeout);
 
     // Unpack projectDetails details
     projectDetails = JSON.parse(decodeURIComponent(projectDetails));

--- a/public/editor/scripts/main.js
+++ b/public/editor/scripts/main.js
@@ -62,7 +62,7 @@ require(["jquery", "bowser", "analytics"], function($, bowser, analytics) {
 
   Bramble.once("error", onError);
 
-  var slowLoadingTimeoutMS = 15000;
+  var slowLoadingTimeoutMS = 10000;
 
   var slowLoadingTimeout = setTimeout(function(){
     showLoadingErrorMessage();


### PR DESCRIPTION
We gave a project 15 seconds to load before showing an error message, but even if the project loaded, we sent off a "slow loading" event to GA causing mass confusion and panic. This clears the timeout that triggered the event when a project loads.

In addition, I dropped the slow loading timeout to ``10s`` so that the message will show up a bit faster. I think this is the right move since our average load time seems to be about 5 seconds, so reaching twice the average might be a good time to step in.

Fixes #2212