### PR TITLE
Fix #2196: Rehash inline style for spinner - style src CSP header

### DIFF
--- a/server/security.js
+++ b/server/security.js
@@ -52,8 +52,7 @@ let defaultCSPDirectives = {
     "https://netdna.bootstrapcdn.com",
     "https://pontoon.mozilla.org",
     // Inline style for the spinner
-    "'unsafe-inline'"
-  //  "'sha256-jxjTomDIR9qe7wntK24mAd+gIoz39DrBll8o6DEBALs='"
+    "'sha256-AnlD8XRHNPxhNZ/6MucKFJr9yYGQtn8bmvveYkBg7a4='"
   ]
 };
 


### PR DESCRIPTION
@gideonthomas Fixes #2196 
I rehashed the spinner inline style and applied it as the CSP rule. I also removed the previously commented out hash, and the 'unsafe-inline' directive.