### PR TITLE
Updating fullscreen layout code

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -17,6 +17,12 @@ define(function(require) {
   var adaptTimeout;
 
   function updateLayout(data) {
+    // If we are in fullscreen mode, we skip all this updating.
+    var isFullscreen = $("body").hasClass("fullscreen-preview");
+    if(isFullscreen) {
+      return;
+    }
+
     $(".filetree-pane-nav").width(data.sidebarWidth);
     $(".editor-pane-nav").width(data.firstPaneWidth);
     $(".preview-pane-nav").width(data.secondPaneWidth);


### PR DESCRIPTION
This stops the panel resizing and UI adapting code from firing when we are in fullscreen mode when it's not needed. The related changes in the brackets PR below also ensure that when you exit fullscreen mode (and if you've changed the browser window size while in fullscreen) all of top bars above the editor panes are the proper size.

To know that this patch is working correctly:
* Open a project
* Enter fullscreen preview mode
* Resize the browser window
  * **Check that** - the "Reload" icon doesn't disappear
* Exit fullscreen mode
  * **Check that** - the UI bars above the editor panels are the correct size

Fixes #2226 when paired with https://github.com/mozilla/brackets/pull/775


