### PR TITLE
Adds GA event tracking when published project is remixed.

### DIFF
--- a/public/resources/remix/index.js
+++ b/public/resources/remix/index.js
@@ -32,7 +32,7 @@
       if(projectMetaEl) {
         var projectID = projectMetaEl.getAttribute("content") || false;
         if(projectID && typeof ga === "function") {
-          ga("send", {
+          window.ga("send", {
             hitType: "event",
             eventCategory: "Remix Bar",
             eventAction: "Project Remixed",

--- a/public/resources/remix/index.js
+++ b/public/resources/remix/index.js
@@ -31,7 +31,7 @@
       var projectMetaEl = document.head.querySelector("[name=data-remix-projectId]");
       if(projectMetaEl) {
         var projectID = projectMetaEl.getAttribute("content") || false;
-        if(projectID && typeof ga === "function") {
+        if(projectID && typeof window.ga === "function") {
           window.ga("send", {
             hitType: "event",
             eventCategory: "Remix Bar",

--- a/public/resources/remix/index.js
+++ b/public/resources/remix/index.js
@@ -30,7 +30,7 @@
     detailsBar.querySelector(".details-bar-remix-button").addEventListener("click",function(event){
       var projectMetaEl = document.head.querySelector("[name=data-remix-projectId]");
       if(projectMetaEl) {
-        var projectID = getAttribute("content") || false;
+        var projectID = projectMetaEl.getAttribute("content") || false;
         if(projectID) {
           ga('send', {
             hitType: 'event',

--- a/public/resources/remix/index.js
+++ b/public/resources/remix/index.js
@@ -4,7 +4,7 @@
  */
 (function(document, head) {
 
-  var gaTrackingId = 'UA-68630113-1';
+  var gaTrackingId = "UA-68630113-1";
 
   function injectAnalytics() {
     var analytics = document.createElement("script");
@@ -31,11 +31,11 @@
       var projectMetaEl = document.head.querySelector("[name=data-remix-projectId]");
       if(projectMetaEl) {
         var projectID = projectMetaEl.getAttribute("content") || false;
-        if(projectID) {
-          ga('send', {
-            hitType: 'event',
-            eventCategory: 'Remix Bar',
-            eventAction: 'Project Remixed',
+        if(projectID && typeof ga === "function") {
+          ga("send", {
+            hitType: "event",
+            eventCategory: "Remix Bar",
+            eventAction: "Project Remixed",
             eventLabel: parseInt(projectID)
           });
         }

--- a/public/resources/remix/index.js
+++ b/public/resources/remix/index.js
@@ -27,7 +27,7 @@
     detailsBar.setAttribute("style", "");
     detailsBar.classList.add("mouse-mode");
 
-    detailsBar.querySelector(".details-bar-remix-button").addEventListener("click",function(event){
+    detailsBar.querySelector(".details-bar-remix-button").addEventListener("click",function(){
       var projectMetaEl = document.head.querySelector("[name=data-remix-projectId]");
       if(projectMetaEl) {
         var projectID = projectMetaEl.getAttribute("content") || false;

--- a/public/resources/remix/index.js
+++ b/public/resources/remix/index.js
@@ -19,13 +19,28 @@
     }
 
     var detailsBar = document.querySelector(".details-bar");
-    
+
     if (!detailsBar) {
       return;
     }
 
     detailsBar.setAttribute("style", "");
     detailsBar.classList.add("mouse-mode");
+
+    detailsBar.querySelector(".details-bar-remix-button").addEventListener("click",function(event){
+      var projectMetaEl = document.head.querySelector("[name=data-remix-projectId]");
+      if(projectMetaEl) {
+        var projectID = getAttribute("content") || false;
+        if(projectID) {
+          ga('send', {
+            hitType: 'event',
+            eventCategory: 'Remix Bar',
+            eventAction: 'Project Remixed',
+            eventLabel: parseInt(projectID)
+          });
+        }
+      }
+    });
 
     detailsBar.addEventListener("click", function(event) {
       if (event.target.classList.contains("thimble-button")) {


### PR DESCRIPTION
This will track the ID of any project that is remixed via the Details Bar in Google Analytics.
Tested and shows up like this...

![image](https://cloud.githubusercontent.com/assets/25212/26564478/0d7b3ee8-4496-11e7-9fcd-b376f322370a.png)

Fixes #2224

I'm not sure how to fix the last two remaining lints @gideonthomas 