### PR TITLE
Add simple load test CLI for remixing a project

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "nunjucks": "^2.3.0",
     "properties-parser": "0.3.1",
     "q-io": "1.13.2",
-    "request": "2.80.0",
+    "request": "^2.80.0",
     "serve-favicon": "^2.4.1",
     "tar-stream": "^1.5.2",
     "throng": "^4.0.0",
@@ -90,7 +90,6 @@
   "devDependencies": {
     "commander": "^2.9.0",
     "pretty-bytes": "^4.0.2",
-    "pretty-ms": "^2.1.0",
-    "request": "^2.80.0"
+    "pretty-ms": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,5 +86,11 @@
     "invalidate": "node scripts/invalidate.js",
     "localize": "node scripts/properties2json.js",
     "localize-client": "node scripts/localize-client.js"
+  },
+  "devDependencies": {
+    "commander": "^2.9.0",
+    "pretty-bytes": "^4.0.2",
+    "pretty-ms": "^2.1.0",
+    "request": "^2.80.0"
   }
 }

--- a/scripts/load-test-remix.js
+++ b/scripts/load-test-remix.js
@@ -1,0 +1,114 @@
+/**
+ * Simulate what Thimble does when a project is remixed. This is a simplification
+ * of the code in public/editor/scripts/project/*.js, which loads a tarball,
+ * project metadata, and sometimes a default HTML file.
+ *
+ * To use this run the following command:
+ *
+ * $ node ./scripts/load-test-remix.js --url https://thimble.mozilla.org -i 1238
+ *
+ * You can specify a different --url (or -u) for staging, local dev, or prod. It will
+ * default to staging.  You must specify an --id (or -i) for the remix ID.
+ */
+
+"use strict";
+
+let program = require("commander");
+let prettyBytes = require("pretty-bytes");
+let prettyMs = require("pretty-ms");
+let request = require("request").defaults({
+    headers: {
+        "User-Agent": "Thimble Load Test"
+    },
+    time: true
+});
+
+program
+    .option("-u, --url [url]", "Host URL", "https://bramble.mofostaging.net")
+    .option("-i, --id <n>", "Remix Project ID")
+    .parse(process.argv);
+
+if(!program.url || !program.id) {
+    program.help();
+    process.exit(1);
+    return;
+}
+
+let host = program.url.replace(/\/$/, "");
+let id = program.id
+let totalTimeMS = 0;
+
+console.log("Running load test for host=%s and id=%s", host, id);
+
+/**
+ * 1) Load project tarball
+ * GET arraybuffer {host}/projects/{remixID or ID}/files/data?cacheBust={Date.now()}
+ */
+function step1() {
+    console.log("Step 1: Loading project tarball");
+    console.log("  Started");
+
+    request.get({
+        encoding: null,
+        url: host + "/projects/" + id + "/files/data?cacheBust=" + Date.now()
+    }, function(error, response, body) {
+        if(error || response.statusCode !== 200) {
+            console.log("  Failed. Got status code %s and error %s.", response.statusCode, error);
+            process.exit(1);
+        } else {
+            totalTimeMS += response.elapsedTime;
+            console.log("  Completed. Loaded %s in %s.", prettyBytes(body.length), prettyMs(response.elapsedTime));
+            step2();
+        }
+    });
+}
+
+/**
+ * 2) Load project metadata
+ * GET JSON {host}/projects/{id}/files/meta?cacheBust={Date.now()}
+ */
+function step2() {
+    console.log("Step 2: Loading project metadata");
+    console.log("  Started");
+
+    request.get({
+        encoding: null,
+        url: host + "/projects/" + id + "/files/meta?cacheBust=" + Date.now()
+    }, function(error, response, body) {
+        if(error || response.statusCode !== 200) {
+            console.log("  Failed. Got status code %s and error %s.", response.statusCode, error);
+            process.exit(1);
+        } else {
+            totalTimeMS += response.elapsedTime;
+            console.log("  Completed. Loaded %s in %s.", prettyBytes(body.length), prettyMs(response.elapsedTime));
+            step3();
+        }
+    });
+}
+
+/**
+ * 3) Install a Default HTML if missing one in the project
+ * GET {host}/default-files/html.txt
+ */
+function step3() {
+    console.log("Step 3: Loading default HTML file");
+    console.log("  Started");
+
+    request.get({
+        encoding: null,
+        url: host + "/default-files/html.txt"
+    }, function(error, response, body) {
+        if(error || response.statusCode !== 200) {
+            console.log("  Failed. Got status code %s and error %s.", response.statusCode, error);
+            process.exit(1);
+        } else {
+            totalTimeMS += response.elapsedTime;
+            console.log("  Completed. Loaded %s in %s.", prettyBytes(body.length), prettyMs(response.elapsedTime));
+
+            console.log("Finished all steps in %s.", prettyMs(totalTimeMS));
+            process.exit(0);
+        }
+    });
+}
+
+step1();

--- a/scripts/load-test-remix.js
+++ b/scripts/load-test-remix.js
@@ -17,50 +17,50 @@ let program = require("commander");
 let prettyBytes = require("pretty-bytes");
 let prettyMs = require("pretty-ms");
 let request = require("request").defaults({
-    headers: {
-        "User-Agent": "Thimble Load Test"
-    },
-    time: true
+  headers: {
+    "User-Agent": "Thimble Load Test"
+  },
+  time: true
 });
 
 program
-    .option("-u, --url [url]", "Host URL", "https://bramble.mofostaging.net")
-    .option("-i, --id <n>", "Remix Project ID")
-    .parse(process.argv);
+  .description("A utility to simulate what Thimble does when a project is remixed")
+  .option("-u, --url [url]", "Host URL", "https://bramble.mofostaging.net")
+  .option("-i, --id <n>", "Remix Project ID")
+  .parse(process.argv);
 
 if(!program.url || !program.id) {
-    program.help();
-    process.exit(1);
-    return;
+  program.help();
+  return;
 }
 
 let host = program.url.replace(/\/$/, "");
-let id = program.id
+let id = program.id;
 let totalTimeMS = 0;
 
 console.log("Running load test for host=%s and id=%s", host, id);
 
 /**
  * 1) Load project tarball
- * GET arraybuffer {host}/projects/{remixID or ID}/files/data?cacheBust={Date.now()}
+ * GET arraybuffer {host}/projects/{id}/files/data?cacheBust={Date.now()}
  */
 function step1() {
-    console.log("Step 1: Loading project tarball");
-    console.log("  Started");
+  console.log("Step 1: Loading project tarball");
+  console.log("  Started");
 
-    request.get({
-        encoding: null,
-        url: host + "/projects/" + id + "/files/data?cacheBust=" + Date.now()
-    }, function(error, response, body) {
-        if(error || response.statusCode !== 200) {
-            console.log("  Failed. Got status code %s and error %s.", response.statusCode, error);
-            process.exit(1);
-        } else {
-            totalTimeMS += response.elapsedTime;
-            console.log("  Completed. Loaded %s in %s.", prettyBytes(body.length), prettyMs(response.elapsedTime));
-            step2();
-        }
-    });
+  request.get({
+    encoding: null,
+    url: host + "/projects/" + id + "/files/data?cacheBust=" + Date.now()
+  }, function(error, response, body) {
+    if(error || response.statusCode !== 200) {
+      console.log("  Failed. Got status code %s and error %s.", response.statusCode, error);
+      process.exit(1);
+    } else {
+      totalTimeMS += response.elapsedTime;
+      console.log("  Completed. Loaded %s in %s.", prettyBytes(body.length), prettyMs(response.elapsedTime));
+      step2();
+    }
+  });
 }
 
 /**
@@ -68,22 +68,22 @@ function step1() {
  * GET JSON {host}/projects/{id}/files/meta?cacheBust={Date.now()}
  */
 function step2() {
-    console.log("Step 2: Loading project metadata");
-    console.log("  Started");
+  console.log("Step 2: Loading project metadata");
+  console.log("  Started");
 
-    request.get({
-        encoding: null,
-        url: host + "/projects/" + id + "/files/meta?cacheBust=" + Date.now()
-    }, function(error, response, body) {
-        if(error || response.statusCode !== 200) {
-            console.log("  Failed. Got status code %s and error %s.", response.statusCode, error);
-            process.exit(1);
-        } else {
-            totalTimeMS += response.elapsedTime;
-            console.log("  Completed. Loaded %s in %s.", prettyBytes(body.length), prettyMs(response.elapsedTime));
-            step3();
-        }
-    });
+  request.get({
+    encoding: null,
+    url: host + "/projects/" + id + "/files/meta?cacheBust=" + Date.now()
+  }, function(error, response, body) {
+    if(error || response.statusCode !== 200) {
+      console.log("  Failed. Got status code %s and error %s.", response.statusCode, error);
+      process.exit(1);
+    } else {
+      totalTimeMS += response.elapsedTime;
+      console.log("  Completed. Loaded %s in %s.", prettyBytes(body.length), prettyMs(response.elapsedTime));
+      step3();
+    }
+  });
 }
 
 /**
@@ -91,24 +91,24 @@ function step2() {
  * GET {host}/default-files/html.txt
  */
 function step3() {
-    console.log("Step 3: Loading default HTML file");
-    console.log("  Started");
+  console.log("Step 3: Loading default HTML file");
+  console.log("  Started");
 
-    request.get({
-        encoding: null,
-        url: host + "/default-files/html.txt"
-    }, function(error, response, body) {
-        if(error || response.statusCode !== 200) {
-            console.log("  Failed. Got status code %s and error %s.", response.statusCode, error);
-            process.exit(1);
-        } else {
-            totalTimeMS += response.elapsedTime;
-            console.log("  Completed. Loaded %s in %s.", prettyBytes(body.length), prettyMs(response.elapsedTime));
+  request.get({
+    encoding: null,
+    url: host + "/default-files/html.txt"
+  }, function(error, response, body) {
+    if(error || response.statusCode !== 200) {
+      console.log("  Failed. Got status code %s and error %s.", response.statusCode, error);
+      process.exit(1);
+    } else {
+      totalTimeMS += response.elapsedTime;
+      console.log("  Completed. Loaded %s in %s.", prettyBytes(body.length), prettyMs(response.elapsedTime));
 
-            console.log("Finished all steps in %s.", prettyMs(totalTimeMS));
-            process.exit(0);
-        }
-    });
+      console.log("Finished all steps in %s.", prettyMs(totalTimeMS));
+      process.exit(0);
+    }
+  });
 }
 
 step1();


### PR DESCRIPTION
This simulates what happens when Thimble remixes a project, loading the files (tarball), project metadata, and a default HTML file.  You can run it like this:

```
node ./scripts/load-test-remix.js --url https://thimble.mozilla.org -i 1235
Running load test for host=https://thimble.mozilla.org and id=1235
Step 1: Loading project tarball
  Started
  Completed. Loaded 34.3 kB in 756ms.
Step 2: Loading project metadata
  Started
  Completed. Loaded 940 B in 620ms.
Step 3: Loading default HTML file
  Started
  Completed. Loaded 359 B in 224ms.
Finished all steps in 1.6s.
```

My thought is that we try and run a bunch of these at once somehow, and push the server.  I'm not sure what a good default project ID would be for each of staging and prod, esp. one that has a lot of files.