### PR TITLE
Added an overlay when modals are open

### DIFF
--- a/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
+++ b/public/editor/scripts/editor/js/fc/bramble-ui-bridge.js
@@ -430,6 +430,14 @@ define(function(require) {
     // Hook up event listeners
     bramble.on("layout", updateLayout);
 
+    bramble.on("dialogOpened", function(){
+      $("body").addClass("modal-open");
+    });
+
+    bramble.on("dialogClosed", function(){
+      $("body").removeClass("modal-open");
+    });
+
     bramble.on("sidebarChange", function(data) {
       // Open/close filetree nav during hidden double click
       if(data.visible) {

--- a/public/editor/stylesheets/editor.less
+++ b/public/editor/stylesheets/editor.less
@@ -28,6 +28,7 @@ body {
 // Logo position overrides
 .navbar-thimble {
   background: #2D9961;
+  position: relative;
 
   .navbar-logo-container.small-logo {
     top: 2px ;
@@ -1244,4 +1245,30 @@ body {
       display: none;
     }
   }
+}
+
+body.modal-open .dialog-overlay {
+  display: block;
+  z-index: 99;
+
+  animation: showModalBackdrop .1s ease-out;
+
+  @keyframes showModalBackdrop {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: .8;
+    }
+  }
+}
+
+.dialog-overlay {
+  position: absolute;
+  display: none;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0,0,0,.8);
 }

--- a/views/editor/bramble.html
+++ b/views/editor/bramble.html
@@ -175,6 +175,7 @@
 
     <div class="bramble-toolbar">
         {% include './nav-options.html' %}
+        <div class="dialog-overlay"></div>
     </div>
     <div id="webmaker-bramble"></div>
     <script src="{{ editorHOST }}/dist/bramble.js"></script>

--- a/views/editor/userbar.html
+++ b/views/editor/userbar.html
@@ -111,6 +111,6 @@
       </div>
     {% endif %}
     </div>
-
+    <div class="dialog-overlay"></div>
   </nav>
 {% endblock %}


### PR DESCRIPTION
This update adds a black overlay over the rest of the Thimble UI when brackets opens a modal dialog, like this...

![image](https://cloud.githubusercontent.com/assets/25212/26608450/807c087c-4550-11e7-9fff-08ac121a9bed.png)

It relies on two new brackets events...

* ``dialogOpened``
* ``dialogClosed``

...which are in https://github.com/mozilla/brackets/pull/778