### PR TITLE
Fix #1991, #1524: prefetch bramble resources using HTML5 <link>s vs. script

### DIFF
--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -1,13 +1,4 @@
 /* global requirejs */
-
-// Because we pre-load require scripts needed by the editor, we need to
-// eat error messages related to fetching but not using those modules.
-requirejs.onError = function(err) {
-  if(err.requireType !== "mismatch") {
-    throw err;
-  }
-};
-
 require.config({
   waitSeconds: 120,
   baseUrl: "/{{ locale }}/homepage/scripts",
@@ -30,21 +21,6 @@ require.config({
     }
   }
 });
-
-// While the user is reading this page, start to cache Bramble's biggest files
-function preloadBramble($) {
-  var brambleHost = $("meta[name='bramble-host']").attr("content");
-  brambleHost = brambleHost.replace(/\/$/, "");
-  [
-    brambleHost + "/dist/styles/brackets.min.css",
-    brambleHost + "/dist/bramble.js",
-    brambleHost + "/dist/main.js",
-    brambleHost + "/dist/thirdparty/thirdparty.min.js"
-  ].forEach(function(url) {
-    // Load and cache files as plain text (don't parse) and ignore results.
-    $.ajax({url: url, dataType: "text"});
-  });
-}
 
 function setupNewProjectLinks($, analytics) {
   var authenticated = $("#navbar-login").hasClass("signed-in");
@@ -124,7 +100,6 @@ function init($, uuid, cookies, PopupMenu, analytics, gallery, getinvolved) {
   setupNewProjectLinks($, analytics);
   gallery.init();
   getinvolved.init();
-  preloadBramble($);
 }
 
 require(['jquery', 'uuid', 'cookies', 'fc/bramble-popupmenu', 'analytics', 'gallery', 'getinvolved'], init);

--- a/views/homepage/base.html
+++ b/views/homepage/base.html
@@ -5,7 +5,13 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-    <meta name="bramble-host" content="{{editorHOST}}">
+
+    <!-- Start prefetching the largest of the editor resources -->
+    <link rel="prefetch" href="{{ editorHOST }}/dist/index.html">
+    <link rel="prefetch" href="{{ editorHOST }}/dist/bramble.js">
+    <link rel="prefetch" href="{{ editorHOST }}/dist/styles/brackets.min.css">
+    <link rel="prefetch" href="{{ editorHOST }}/dist/thirdparty/thirdparty.min.js">
+    <link rel="prefetch" href="{{ editorHOST }}/dist/main.js">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@mozlearn">


### PR DESCRIPTION
Finishing work started by @evantsyferov in #2013 and @Mordax in #2008.  This removes the hacked preloading of Bramble's large assets, and uses [<link> prefetching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ) instead.

The effect is the same, but this is a lot cleaner, and it also lets us get the `index.html` cached early for the editor too. 