### PR TITLE
Fixed a bug that keeps the Publish button visible after publishing

### DIFF
--- a/public/editor/stylesheets/publish.less
+++ b/public/editor/stylesheets/publish.less
@@ -123,6 +123,10 @@
     justify-content: flex-end;
     align-items: flex-start;
 
+    &.hide {
+      display: none;
+    }
+
     #publish-button-publish {
       margin-left: 10px;
       .publish-button;


### PR DESCRIPTION
Fixes a bug introduced in a previous PR that kept the Publish & Cancel buttons visible even after a project has been published.

To test...

* Publish a project
* Once published, the Publish & Cancel buttons on the dialog should disappear

Dialog should look like this (again)...

<img src="https://cloud.githubusercontent.com/assets/25212/26740740/a666bae0-478b-11e7-963e-764c5a57b052.png" width="400"/>

Fixes #2253