### PR TITLE
Allow loading projects as either a single tarball (default) or expanded files

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -66,7 +66,8 @@
             "merge_logs": true,
             "cwd": "/vagrant",
             "env": {
-                "NODE_ENV": "development"
+                "NODE_ENV": "development",
+                "PROJECT_LOAD_STRATEGY": "tarball"
             }
         }
     ]

--- a/env.dist
+++ b/env.dist
@@ -95,3 +95,7 @@ export SIX_WORD_SUMMER_KIT_URL="https://d157rqmxrxj6ey.cloudfront.net/mozillalea
 
 # Debug flag for logging asserts on user token, see https://github.com/mozilla/thimble.mozilla.org/issues/2161
 export ASSERT_TOKEN=false
+
+# Specify how projects are loaded: load as single tarball ("tarball") or as separate files ("files").
+# The default is "tarball" if not specified.
+export PROJECT_LOAD_STRATEGY=tarball

--- a/locales/fr/messages.properties
+++ b/locales/fr/messages.properties
@@ -66,6 +66,10 @@ navHTMLFile=Ajouter un fichier HTML
 navCSSFile=Ajouter un fichier CSS
 navJavascriptFile=Ajouter un fichier JavaScript
 navTutorialFile=Ajouter un tutoriel
+# Tooltip shown for adding a new folder in the files menu
+navAddFolderTitle=Ajouter un nouveau dossier
+# Text to display in the files menu for adding a new folder
+navAddFolder=Ajouter un dossier
 navUploadFile=Envoyer un fichier…
 navEditor=ÉDITEUR
 navUndo=Annuler
@@ -112,6 +116,7 @@ snippetHTMLScript=Inclure un fichier JavaScript
 snippetHTMLScriptTitle=Ajouter un script
 snippetHTMLExternalStylesheet=Inclure un fichier CSS
 snippetHTMLExternalStylesheetTitle=Ajouter une feuille de style externe
+snippetHTMLExternalStyleSheetComment=Ajoutez la balise <link> à votre fichier HTML. Elles sont généralement placées dans la balise <head>
 snippetHTMLVideo=Lecteur vidéo
 snippetHTMLVideoTitle=Ajouter un lecteur vidéo à votre page
 # Text that shows up between the <video> and </video> tags as a fallback
@@ -214,6 +219,7 @@ publishUnpublishingIndicator=Retrait du projet…
 publishProjectDescription=Description du projet
 publishCancelBtn=Annuler
 publishDeleteWarning=Voulez-vous vraiment supprimer la version publiée ? Le lien actuel cessera de fonctionner et si vous publiez à nouveau, le lien sera différent.
+noIndexFound=Veuillez ajouter un fichier <strong>« index.html »</strong> avant de publier votre projet. <a href="{{ learnMoreURL }}">En savoir plus</a>
 
 ##################
 ## Project List ##

--- a/locales/it/messages.properties
+++ b/locales/it/messages.properties
@@ -119,27 +119,52 @@ snippetHTMLAudioTitle=Aggiungi un lettore audio alla tua pagina
 snippetHTMLAudioData=Il tuo browser non supporta i tag audio.
 snippetCSSComment=Commento
 snippetCSSCommentTitle=Aggiungi un commento al file CSS
+snippetCSSTagNameSelectorTitle=Personalizza un tag col nome
+snippetCSSClassSelectorTitle=Personalizza gli elementi con una classe
+snippetCSSIDSelectorTitle=Prsonalizza un elemento tramite il suo ID
 # Description of animation code inside a CSS comment /* The animation code */
 # Description of animation code inside a CSS comment /* The element to apply the animation to */
 # Description of unvisited anchor CSS selector inside a CSS comment /* unvisited link */
+snippetCSSAnchorStyleUnvisitedLinkComment=Stile base
 # Description of visited anchor CSS selector inside a CSS comment /* visited link */
+snippetCSSAnchorStyleVisitedLinkComment=Visitato
 # Description of mouseover anchor CSS selector inside a CSS comment /* mouseover link */
 # Description of selected anchor CSS selector inside a CSS comment /* selected link */
+snippetCSSAnchorStyleActiveLinkComment=Attivo
+snippetCSSMediaQuery=Media Query
+snippetCSSMediaQueryTitle=Aggiungi una Media Query
 # Description of data to add for a CSS media query inside a CSS comment /* Rules when screen is up to 320px wide */
 # Description of data to add for a CSS media query inside a CSS comment /* Rules when screen is between 321px and 768px wide */
 # Description of data to add for a CSS media query inside a CSS comment /* Rules when screen is wider than 768px */
+snippetCSSFont=Font
+snippetCSSPseudoTitle=Aggiungi contenuto alla pagina con CSS utilizzando un elemento pseudo
 # Description of an example :after CSS pseudo selector that will show up in CSS comment /* Adds an arrow before every element with class='arrow' */
 # This will go inside a console.log(). Please leave the quotes in the translated string and do not translate `name` as it is a javascript variable. For eg. the string will be displayed as `console.log("Hello, " + name);`
 # This will go inside a console.log().
 # A common person's name that will be used in a snippet. For e.g. `functionCall("David")`
+snippetJSPersonName1=David
 # A common person's name that will be used in a snippet. For e.g. `functionCall("Bob")`
+snippetJSPersonName2=Bob
 # A common person's name that will be used in a snippet. For e.g. `functionCall("Kate")`
+snippetJSPersonName3=Kate
+snippetJSForLoop=Ciclo For
+snippetJSForLoopTitle=Aggiungi un ciclo For
 # Description of what needs to happen inside a JS loop as a JS comment // Do something in this loop
+snippetJSWhileLoop=Ciclo While
+snippetJSWhileLoopTitle=Aggiungi un ciclo While
+snippetJSSwitchCase=Istruzione di Switch
+snippetJSSwitchCaseTitle=Aggiungi un condizionale Switch/Case
 # Description of what needs to happen inside a JS conditional block (if/switch) as a JS comment // Do something for this case
 # Description of what needs to happen inside the fallback JS conditional block (else/default) as a JS comment // Do something if no condition was met
+snippetJSIfElse=Istruzione If...Else
+snippetJSIfElseTitle=Aggiungi una condizione If...Else
+snippetJSObject=Oggetto
+snippetJSClickHandler=Aggiungi un evento click
 # Description of an example of using document.querySelector() which will show up in a JS comment // Select an element with id="button"
 # Will show up as `console.log("Click!")`
+snippetJSClickHandlerLog=Clic!
 # Description of an example of changing an HTML element's style in JS which will show up in a JS comment // Select the element with id='alert'
+snippetJSChangeStyleComment=Seleziona l'elemento con id='alert'
 
 # Publishing
 publishHeader=Pubblica il progetto
@@ -159,14 +184,18 @@ publishDeleteWarning=Intendi davvero eliminare questa versione? L'attuale colleg
 
 prjListNewProjectBtn=Crea nuovo progetto
 prjListDeleteProjectBtn=Elimina
+prjListCancelDeleteProjectBtn=Annulla
 momentJSLastEdited=Ultima modifica <% timeElapsed %>
 publishedLink=Versione pubblicata
+deleteProjects=Elimina i progetti
 
 ###################
 ## Features page ##
 ###################
 
 
+livePreviewFeatureTitle=Vedi istantaneamente le modifiche
+fileTreeFeatureTitle=Aggiungere e gestire i file
 
 #######################
 ## Get Involved page ##

--- a/locales/it/messages.properties
+++ b/locales/it/messages.properties
@@ -8,7 +8,7 @@
 ## Homepage ##
 ##############
 
-thimbleHeading=Thimble di Mozilla - L'editor di codice online per principianti ed educatori.
+thimbleHeading=Thimble di Mozilla – L'editor di codice online per principianti ed educatori.
 thimbleTagLine=Scrivere il Web <br/> sul Web
 thimbleDescription1=Thimble è un editor di codice online che rende possibile creare e pubblicare pagine web mentre si imparano i linguaggi <a title="Imparare l'HTML " href="https://developer.mozilla.org/docs/Learn/HTML">HTML</a>, <a title="Imparare il CSS" href="https://developer.mozilla.org/docs/Learn/CSS">CSS</a> e <a title="Imparare JavaScript" href="https://developer.mozilla.org/docs/Learn/JavaScript">JavaScript</a>.
 newProjectBtn=Inizia un progetto da zero
@@ -19,7 +19,7 @@ contribute=Collabora su Github
 termsOfUse=Condizioni di utilizzo
 privacyPolicy=Informativa sulla privacy
 thimbleFooter=Thimble è parte di Mozilla Learning Newtork. <br/> Per imparare ad insegnare nello stile Mozilla consulta <a href="http://learning.mozilla.org"> learning.mozilla.org</a>.
-pageTitleGetInvolved=Thimble di Mozilla - Collabora con noi
+pageTitleGetInvolved=Thimble di Mozilla – Collabora con noi
 
 
 # Userbar

--- a/public/editor/scripts/project/metadata.js
+++ b/public/editor/scripts/project/metadata.js
@@ -286,7 +286,7 @@ define(function(require) {
 
   function install(config, callback) {
     if(!config.user) {
-      loadAnonymous(config, callback);
+      return loadAnonymous(config, callback);
     }
 
     setMetadata(config, callback);

--- a/public/editor/scripts/project/metadata.js
+++ b/public/editor/scripts/project/metadata.js
@@ -238,7 +238,7 @@ console.log("config.data", config.data);
 
   // Downloads project metadata (project id, file paths + publish ids).
   function download(config, callback) {
-    if(config.update) {
+    if(!config.user || config.update) {
       // There is no metadata to fetch from the server if this project is
       // being upgraded from an anonymous to a persisted project (we push
       // metadata to the server instead of downloading it)

--- a/public/editor/scripts/project/metadata.js
+++ b/public/editor/scripts/project/metadata.js
@@ -236,7 +236,12 @@ define(function(require) {
     });
   }
 
-  function fetchMetadata(config, callback) {
+  // Downloads project metadata (project id, file paths + publish ids).
+  function download(config, callback) {
+    if(!config.user) {
+      return callback(null, null);
+    }
+
     var url = config.host + "/projects";
     if (config.id) {
       url += "/" + config.id;
@@ -279,24 +284,12 @@ define(function(require) {
     });
   }
 
-  function load(config, callback) {
-    if (config.user) {
-      if (config.update) {
-        return setMetadata(config, callback);
-      }
-
-      return fetchMetadata(config, function(err, data) {
-        setMetadata({
-          data: data,
-          id: config.id,
-          root: config.root,
-          user: config.user,
-          title: config.title
-        }, callback);
-      });
+  function install(config, callback) {
+    if(!config.user) {
+      loadAnonymous(config, callback);
     }
 
-    loadAnonymous(config, callback);
+    setMetadata(config, callback);
   }
 
   function update(config, callback) {
@@ -325,7 +318,8 @@ define(function(require) {
   }
 
   return {
-    load: load,
+    download: download,
+    install: install,
     update: update,
     getFileID: getFileID,
     setFileID: setFileID,

--- a/public/editor/scripts/project/metadata.js
+++ b/public/editor/scripts/project/metadata.js
@@ -238,11 +238,10 @@ define(function(require) {
 
   // Downloads project metadata (project id, file paths + publish ids).
   function download(config, callback) {
-    if(!config.user || config.update) {
-      // There is no metadata to fetch from the server if this project is:
-      // 1. anonymous, or
-      // 2. being upgraded from an anonymous to a persisted project (we push
-      //    metadata to the server instead of downloading it)
+    if(config.update) {
+      // There is no metadata to fetch from the server if this project is
+      // being upgraded from an anonymous to a persisted project (we push
+      // metadata to the server instead of downloading it)
       return callback(null, null);
     }
 

--- a/public/editor/scripts/project/metadata.js
+++ b/public/editor/scripts/project/metadata.js
@@ -226,7 +226,7 @@ define(function(require) {
       // [{ id: 1, path: "/index.html", project_id: 3 }, ... ]
       if (config.data) {
         project.id = config.id;
-
+console.log("config.data", config.data);
         config.data.forEach(function(info) {
           project.paths[info.path] = info.id;
         });

--- a/public/editor/scripts/project/metadata.js
+++ b/public/editor/scripts/project/metadata.js
@@ -226,7 +226,7 @@ define(function(require) {
       // [{ id: 1, path: "/index.html", project_id: 3 }, ... ]
       if (config.data) {
         project.id = config.id;
-console.log("config.data", config.data);
+
         config.data.forEach(function(info) {
           project.paths[info.path] = info.id;
         });

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -185,7 +185,8 @@ define(function(require) {
     // Step 1: download the project's metadata
     Metadata.download({
       host: _host,
-      id: _id
+      id: _id,
+      user: _user
     }, function(err, data) {
       if(err) {
         return callback(err);

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -179,85 +179,95 @@ define(function(require) {
 
   // Set all necesary data for this project, based on makeDetails rendered into page.
   function _load(csrfToken, syncQueue, callback) {
-    // Step 1: download the project's contents (files + metadata) or upload an
-    // anonymous project's content if this is an upgrade, and install into the root
-    Remote.loadProject({
-      root: getRoot(),
+    var now = (new Date()).toISOString();
+    var isUpdate = !!_user && !!_anonymousId;
+
+    // Step 1: download the project's metadata
+    Metadata.download({
       host: _host,
-      user: _user,
-      id: _id,
-      remixId: _remixId,
-      anonymousId: _anonymousId,
-      syncQueue: syncQueue
-    }, function(err, pathUpdatesCache) {
+      id: _id
+    }, function(err, data) {
       if(err) {
-        // If we have paths to sync in the SyncQueue, ignore this error and keep going
-        if(!Object.keys(syncQueue.pending).length) {
-          return callback(err);
-        }
+        return callback(err);
       }
 
-      // If there are cached paths that need to be updated, queue those now
-      if(pathUpdatesCache && pathUpdatesCache.length) {
-        pathUpdatesCache.forEach(function(path) {
-          queueFileUpdate(path);
-        });
-      }
-
-      var now = (new Date()).toISOString();
-      var isUpdate = !!_user && !!_anonymousId;
-
-      // Step 2: If this was a project upgrade (from anonymous to authenticated),
-      // update the project metadata on the server
-      Metadata.update({
+      // Step 2: download the project's contents (files) or upload an
+      // anonymous project's content if this is an upgrade, and install into the root
+      Remote.loadProject({
+        root: getRoot(),
         host: _host,
-        update: isUpdate,
+        user: _user,
         id: _id,
-        csrfToken: csrfToken,
-        data: {
-          title: _title,
-          description: _description,
-          dateCreated: now,
-          dateUpdated: now
-        }
-      }, function(err) {
+        remixId: _remixId,
+        anonymousId: _anonymousId,
+        syncQueue: syncQueue,
+        data: data
+      }, function(err, pathUpdatesCache) {
         if(err) {
-          return callback(err);
+          // If we have paths to sync in the SyncQueue, ignore this error and keep going
+          if(!Object.keys(syncQueue.pending).length) {
+            return callback(err);
+          }
         }
 
-        // Step 3: download the project's metadata (project + file IDs on publish) and
-        // install into an xattrib on the project root.
-        Metadata.load({
-          root: getRoot(),
+        // If there are cached paths that need to be updated, queue those now
+        if(pathUpdatesCache && pathUpdatesCache.length) {
+          pathUpdatesCache.forEach(function(path) {
+            queueFileUpdate(path);
+          });
+        }
+
+        // Step 2: If this was a project upgrade (from anonymous to authenticated),
+        // update the project metadata on the server
+        Metadata.update({
           host: _host,
-          user: _user,
-          remixId: _remixId,
-          id: _id,
-          title: _title,
           update: isUpdate,
+          id: _id,
+          csrfToken: csrfToken,
+          data: {
+            title: _title,
+            description: _description,
+            dateCreated: now,
+            dateUpdated: now
+          }
         }, function(err) {
           if(err) {
             return callback(err);
           }
 
-          // Find the index.html file in the project root to open
-          var indexLocation = Path.join(getRoot(), "index.html");
-          _fs.exists(indexLocation, function(exists) {
-            if(exists) {
-              callback(null, indexLocation);
-              return;
+          // Step 3: install the project's metadata (project + file IDs on publish) and
+          // install into an xattrib on the project root.
+          Metadata.install({
+            root: getRoot(),
+            title: _title,
+            id: _id,
+            data: data,
+            user: _user,
+            update: isUpdate
+          }, function(err) {
+            if(err) {
+              return callback(err);
             }
-            // Create a default index.html file
-            $.get(DEFAULT_INDEX_HTML_URL).then(function(data) {
-              _fs.writeFile(indexLocation, data, function(err) {
-                if (err) {
-                  console.error("Cannot write file to project: " + err);
-                  callback(err);
-                  return;
-                }
+
+            // Find the index.html file in the project root to open
+            var indexLocation = Path.join(getRoot(), "index.html");
+            _fs.exists(indexLocation, function(exists) {
+              if(exists) {
                 callback(null, indexLocation);
-              });
-            }, callback);
+                return;
+              }
+              // Create a default index.html file
+              $.get(DEFAULT_INDEX_HTML_URL).then(function(data) {
+                _fs.writeFile(indexLocation, data, function(err) {
+                  if (err) {
+                    console.error("Cannot write file to project: " + err);
+                    callback(err);
+                    return;
+                  }
+                  callback(null, indexLocation);
+                });
+              }, callback);
+            });
           });
         });
       });

--- a/public/editor/scripts/project/project.js
+++ b/public/editor/scripts/project/project.js
@@ -17,6 +17,7 @@ define(function(require) {
   var _anonymousId;
   var _remixId;
   var _description;
+  var _projectLoadStrategy;
 
   var DEFAULT_INDEX_HTML_URL = "/default-files/html.txt";
 
@@ -147,6 +148,7 @@ define(function(require) {
     _publishUrl = projectDetails.publishUrl;
     _fs = Bramble.getFileSystem();
     _description = projectDetails.description;
+    _projectLoadStrategy = projectDetails.projectLoadStrategy;
 
     var metadataLocation = _user && _anonymousId ? Path.join(Constants.ANONYMOUS_USER_FOLDER, _anonymousId.toString()) : getRoot();
 
@@ -203,7 +205,8 @@ define(function(require) {
         remixId: _remixId,
         anonymousId: _anonymousId,
         syncQueue: syncQueue,
-        data: data
+        data: data,
+        projectLoadStrategy: _projectLoadStrategy
       }, function(err, pathUpdatesCache) {
         if(err) {
           // If we have paths to sync in the SyncQueue, ignore this error and keep going

--- a/public/editor/scripts/project/remote.js
+++ b/public/editor/scripts/project/remote.js
@@ -229,7 +229,8 @@ define(function(require) {
             return callback(err);
           }
 
-          load(config, callback);
+          // Prefer loading as tarball if this is the default project, even if loadfiles=1.
+          loadTarball(config, callback);
         });
       } else {
         callback();

--- a/public/editor/scripts/project/remote.js
+++ b/public/editor/scripts/project/remote.js
@@ -105,7 +105,7 @@ define(function(require) {
     }
 
     var root = config.root;
-    var url = config.host + "/projects/file/";
+    var url = config.host + "/files/";
 
     $.when.apply($, config.data.map(function(fileInfo) {
       var deferred = $.Deferred();

--- a/public/editor/scripts/project/remote.js
+++ b/public/editor/scripts/project/remote.js
@@ -22,7 +22,6 @@ define(function(require) {
   function installTarball(config, tarball, callback) {
     var untarWorker;
     var pending = null;
-    var sh = new fs.Shell();
     var root = config.root;
     var pendingOperations = config.syncQueue.pending;
 
@@ -197,7 +196,7 @@ define(function(require) {
   function load(config, callback) {
     // Support loading projects as a single tarball or as a set of individual files.
     // Default to loading a tarball.
-    var loadProjectAsFiles = window.location.search.indexOf("loadfiles=1") > -1
+    var loadProjectAsFiles = window.location.search.indexOf("loadfiles=1") > -1;
 
     if(loadProjectAsFiles) {
       console.log("[Thimble] Overriding project tarball load strategy, load project files instead.");

--- a/public/editor/scripts/project/remote.js
+++ b/public/editor/scripts/project/remote.js
@@ -195,11 +195,9 @@ define(function(require) {
 
   function load(config, callback) {
     // Support loading projects as a single tarball or as a set of individual files.
+    // Change the value via .env on the server and the PROJECT_LOAD_STRATEGY variable.
     // Default to loading a tarball.
-    var loadProjectAsFiles = window.location.search.indexOf("loadfiles=1") > -1;
-
-    if(loadProjectAsFiles) {
-      console.log("[Thimble] Overriding project tarball load strategy, load project files instead.");
+    if(config.projectLoadStrategy === "files") {
       loadFiles(config, callback);
     } else {
       loadTarball(config, callback);

--- a/public/editor/scripts/project/remote.js
+++ b/public/editor/scripts/project/remote.js
@@ -152,13 +152,26 @@ define(function(require) {
     });
   }
 
+  function load(config, callback) {
+    // Support loading projects as a single tarball or as a set of individual files.
+    // Default to loading a tarball.
+    var loadProjectAsFiles = window.location.search.indexOf("loadfiles=1") > -1
+
+    if(loadProjectAsFiles) {
+      console.log("[Thimble] Overriding project tarball load strategy, load project files instead.");
+      loadFiles(config, callback);
+    } else {
+      loadTarball(config, callback);
+    }
+  }
+
   function loadProject(config, callback) {
     if (config.user) {
       if (config.anonymousId) {
         return upgradeAnonymousProject(config, callback);
       }
 
-      return loadTarball(config, callback);
+      return load(config, callback);
     }
 
     // First, check if this anonymous project already exists by checking the
@@ -175,7 +188,7 @@ define(function(require) {
             return callback(err);
           }
 
-          loadTarball(config, callback);
+          load(config, callback);
         });
       } else {
         callback();

--- a/public/editor/scripts/project/remote.js
+++ b/public/editor/scripts/project/remote.js
@@ -105,7 +105,7 @@ define(function(require) {
     }
 
     var root = config.root;
-    var url = config.host + "/project/file/";
+    var url = config.host + "/projects/file/";
 
     $.when.apply($, config.data.map(function(fileInfo) {
       var deferred = $.Deferred();

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -25,5 +25,7 @@ module.exports = {
   editorHOST: editorHOST,
   editorURL: env.get("NODE_ENV") === "development" ? env.get("BRAMBLE_URI") + "/src" : env.get("BRAMBLE_URI") + "/dist",
   cryptr: new Cryptr(env.get("SESSION_SECRET")),
-  DEFAULT_PROJECT_TITLE: env.get("DEFAULT_PROJECT_TITLE")
+  DEFAULT_PROJECT_TITLE: env.get("DEFAULT_PROJECT_TITLE"),
+  // One of "tarball" (default) or "files" to specify how projects should get loaded.
+  projectLoadStrategy: env.get("PROJECT_LOAD_STRATEGY") === "files" ? "files" : "tarball"
 };

--- a/server/routes/files/index.js
+++ b/server/routes/files/index.js
@@ -8,8 +8,9 @@ module.exports = {
       read.data.bind(app, config));
 
     // Get the file data for a given file id
-    app.get("/projects/files/:id",
+    app.get("/files/:fileId",
       middleware.setErrorMessage("errorGettingProjectFiles"),
+      middleware.checkForAuth,
       middleware.setUserIfTokenExists,
       read.file.bind(app, config));
 

--- a/server/routes/files/index.js
+++ b/server/routes/files/index.js
@@ -7,9 +7,16 @@ module.exports = {
       middleware.setUserIfTokenExists,
       read.data.bind(app, config));
 
+    // Get the file data for a given file id
+    app.get("/projects/files/:id",
+      middleware.setErrorMessage("errorGettingProjectFiles"),
+      middleware.setUserIfTokenExists,
+      read.file.bind(app, config));
+
     // Get all file metadata for a project
     app.get("/projects/:projectId?/files/meta",
       middleware.setErrorMessage("errorGettingProjectFiles"),
+      middleware.checkForAuth,
       middleware.setUserIfTokenExists,
       read.metadata.bind(app, config));
 

--- a/server/routes/files/read/data.js
+++ b/server/routes/files/read/data.js
@@ -9,7 +9,7 @@ module.exports = function(config, req, res) {
   // being remixed and the `projectId` corresponds to a published
   // project
   if(!user && projectId) {
-    sendResponse(res, utils.getRemixedProjectFileTar(config, projectId));
+    utils.sendResponseStream(res, utils.getRemixedProjectFileTar(config, projectId));
     return;
   }
 

--- a/server/routes/files/read/file.js
+++ b/server/routes/files/read/file.js
@@ -1,0 +1,28 @@
+var utils = require("../../utils");
+
+function sendResponse(res, tarStream) {
+  // NOTE: this should be `application/x-tar`, but IE won't decompress the
+  // stream if we use that.  With `application/octet-stream` it works everywhere.
+  res.type("application/octet-stream");
+  tarStream
+  .on("error", function(err) {
+    console.error("Failed to stream tar with: ", err);
+  })
+  .pipe(res);
+}
+
+module.exports = function(config, req, res) {
+  var projectId = req.params.projectId;
+  var user = req.user;
+
+  // If this is an anonymous request and a `projectId` was passed in,
+  // this is a request for getting files for a project that is
+  // being remixed and the `projectId` corresponds to a published
+  // project
+  if(!user && projectId) {
+    sendResponse(res, utils.getRemixedProjectFileTar(config, projectId));
+    return;
+  }
+
+  sendResponse(res, utils.getProjectFileTar(config, user, projectId));
+};

--- a/server/routes/files/read/file.js
+++ b/server/routes/files/read/file.js
@@ -1,28 +1,17 @@
 var utils = require("../../utils");
+var HttpError = require("../../../lib/http-error");
 
-function sendResponse(res, tarStream) {
-  // NOTE: this should be `application/x-tar`, but IE won't decompress the
-  // stream if we use that.  With `application/octet-stream` it works everywhere.
-  res.type("application/octet-stream");
-  tarStream
-  .on("error", function(err) {
-    console.error("Failed to stream tar with: ", err);
-  })
-  .pipe(res);
-}
-
-module.exports = function(config, req, res) {
-  var projectId = req.params.projectId;
+module.exports = function(config, req, res, next) {
+  var fileId = req.params.fileId;
   var user = req.user;
 
-  // If this is an anonymous request and a `projectId` was passed in,
-  // this is a request for getting files for a project that is
-  // being remixed and the `projectId` corresponds to a published
-  // project
-  if(!user && projectId) {
-    sendResponse(res, utils.getRemixedProjectFileTar(config, projectId));
-    return;
-  }
+  utils.getProjectFile(config, user, fileId, function(err, buffer) {
+    if(err) {
+      res.status(500);
+      next(HttpError.format(err, req));
+      return;
+    }
 
-  sendResponse(res, utils.getProjectFileTar(config, user, projectId));
+    res.status(200).send(buffer);
+  });
 };

--- a/server/routes/files/read/file.js
+++ b/server/routes/files/read/file.js
@@ -1,5 +1,4 @@
 var utils = require("../../utils");
-var HttpError = require("../../../lib/http-error");
 
 module.exports = function(config, req, res) {
   var fileId = req.params.fileId;

--- a/server/routes/files/read/file.js
+++ b/server/routes/files/read/file.js
@@ -5,9 +5,9 @@ module.exports = function(config, req, res, next) {
   var fileId = req.params.fileId;
   var user = req.user;
 
-  utils.getProjectFile(config, user, fileId, function(err, buffer) {
+  utils.getProjectFile(config, user, fileId, function(err, status, buffer) {
     if(err) {
-      res.status(500);
+      res.status(status);
       next(HttpError.format(err, req));
       return;
     }

--- a/server/routes/files/read/index.js
+++ b/server/routes/files/read/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   data: require("./data"),
-  metadata: require("./metadata")
+  metadata: require("./metadata"),
+  file: require("./file")
 };

--- a/server/routes/main/editor.js
+++ b/server/routes/main/editor.js
@@ -6,8 +6,12 @@ var querystring = require("querystring");
 var defaultProjectNameKey = require("../../../constants").DEFAULT_PROJECT_NAME_KEY;
 var utils = require("../utils");
 var HttpError = require("../../lib/http-error");
-
+var env = require("../../lib/environment");
 var snippets = require("../../lib/snippets");
+
+// One of "tarball" or "files" to specify how projects should get loaded.
+// If not specified, the client code will default to "tarball".
+var projectLoadStrategy = env.get("PROJECT_LOAD_STRATEGY");
 
 function getProjectMetadata(config, req, callback) {
   var project = req.project;
@@ -26,7 +30,8 @@ function getProjectMetadata(config, req, callback) {
       dateUpdated: project.date_updated,
       tags: project.tags,
       description: project.description,
-      publishUrl: project.publish_url
+      publishUrl: project.publish_url,
+      projectLoadStrategy: projectLoadStrategy
     });
     return;
   }

--- a/server/routes/main/editor.js
+++ b/server/routes/main/editor.js
@@ -6,12 +6,7 @@ var querystring = require("querystring");
 var defaultProjectNameKey = require("../../../constants").DEFAULT_PROJECT_NAME_KEY;
 var utils = require("../utils");
 var HttpError = require("../../lib/http-error");
-var env = require("../../lib/environment");
 var snippets = require("../../lib/snippets");
-
-// One of "tarball" or "files" to specify how projects should get loaded.
-// If not specified, the client code will default to "tarball".
-var projectLoadStrategy = env.get("PROJECT_LOAD_STRATEGY");
 
 function getProjectMetadata(config, req, callback) {
   var project = req.project;
@@ -31,7 +26,7 @@ function getProjectMetadata(config, req, callback) {
       tags: project.tags,
       description: project.description,
       publishUrl: project.publish_url,
-      projectLoadStrategy: projectLoadStrategy
+      projectLoadStrategy: config.projectLoadStrategy
     });
     return;
   }

--- a/server/routes/utils.js
+++ b/server/routes/utils.js
@@ -319,7 +319,7 @@ function getProjectFile(config, user, fileId, callback) {
     }
 
     try {
-      callback(null, new Buffer(body.buffer.data));
+      callback(null, 200, new Buffer(body.buffer.data));
     } catch(e) {
       callback({
         message: `Project data received by the publish server for ${url} was in an invalid format.`,

--- a/server/routes/utils.js
+++ b/server/routes/utils.js
@@ -292,6 +292,44 @@ function getProjectFileTar(config, user, projectId) {
   });
 }
 
+function getProjectFile(config, user, fileId, callback) {
+  var url = config.publishURL + "/files/" + fileId;
+
+  return request.get({
+    json: true,
+    url: url,
+    headers: {
+      "Authorization": "token " + user.token
+    }
+  }, function(err, response, body) {
+    if(err) {
+      callback({
+        message: "Failed to send request to " + url,
+        context: err
+      }, 500);
+      return;
+    }
+
+    if(response.statusCode !== 200) {
+      callback({
+        message: "Request to " + url + " returned a status of " + response.statusCode,
+        context: response.body
+      }, response.statusCode);
+      return;
+    }
+
+    try {
+      callback(null, new Buffer(body.buffer.data));
+    } catch(e) {
+      callback({
+        message: `Project data received by the publish server for ${url} was in an invalid format.`,
+        context: e.message,
+        stack: e.stack
+      }, 500);
+    }
+  });
+}
+
 function getRemixedProjectFileMetadata(config, projectId, callback) {
   var publishURL = config.publishURL + "/publishedProjects/" + projectId + "/publishedFiles/meta";
 
@@ -341,6 +379,7 @@ module.exports = {
   getRemixedProject: getRemixedProject,
   getProjectFileMetadata: getProjectFileMetadata,
   getProjectFileTar: getProjectFileTar,
+  getProjectFile: getProjectFile,
   getRemixedProjectFileMetadata: getRemixedProjectFileMetadata,
   getRemixedProjectFileTar: getRemixedProjectFileTar
 };

--- a/server/routes/utils.js
+++ b/server/routes/utils.js
@@ -292,7 +292,7 @@ function getProjectFileTar(config, user, projectId) {
   });
 }
 
-function getProjectFile(config, user, fileId, callback) {
+function getProjectFile(config, user, fileId) {
   var url = config.publishURL + "/files/" + fileId;
 
   return request.get({


### PR DESCRIPTION
This alters the Thimble client and server to allow for a project to be loaded either as a tarball, or as a set of separate files.  I'm doing this behind an opt-in flag, because I want to experiment with it.  I'm curious to see what will happen if we remove the tarball creation from publish.  It is not fully optimized (e.g., I would need to modify publish to send `Buffer` vs. JSON), but that shouldn't matter too much.

To make this work, I've changed the project load order to load the metadata first.  This gives the file IDs if I need them for loading an expanded set of files.

To use it, add `?loadfiles=1` to the Thimble URL.  If you do nothing, it should load the project as a tarball like normal.