### PR TITLE
Fix #2014: add http:// protocol to PUBLIC_PROJECT_ENDPOINT

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -29,7 +29,7 @@
                 "NODE_ENV": "development",
                 "DATABASE_URL": "postgres://thimble:thimble@localhost:5432/publish",
                 "S3_EMULATION": true,
-                "PUBLIC_PROJECT_ENDPOINT": "localhost:8001",
+                "PUBLIC_PROJECT_ENDPOINT": "http://localhost:8001",
                 "API_HOST": "0.0.0.0",
                 "PORT": 2015,
                 "REMIX_SCRIPT": "http://localhost:3500/resources/remix/index.js",


### PR DESCRIPTION
Other part of this is in https://github.com/mozilla/publish.webmaker.org/issues/250.