### PR TITLE
inject remix script for html with missing <head> tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "helmet": "^3.5.0",
     "jit-grunt": "^0.10.0",
     "jquery": "^3.2.1",
+    "jsdom": "^11.0.0",
     "less-middleware": "2.2.0",
     "memorystream": "^0.3.1",
     "moment": "~2.17.1",
@@ -86,5 +87,8 @@
     "invalidate": "node scripts/invalidate.js",
     "localize": "node scripts/properties2json.js",
     "localize-client": "node scripts/localize-client.js"
+  },
+  "devDependencies": {
+    "eslint": "^3.19.0"
   }
 }


### PR DESCRIPTION
Addresses issue #2241.

Uses [jsdom](https://www.npmjs.com/package/jsdom) to build DOM from html string and query for missing `<head>` tags.  If they do not exist, adds empty `<head>` and `<title>` tags:

i.e. https://thimbleprojects.org/jgmac1106/223453/

```html
<!DOCTYPE html>
<header>
  <script src="https://use.fontawesome.com/e83e9b1e77.js"></script>
  <!-- Latest compiled and minified CSS --> 
  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTs
  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
  <!-- Latest compiled and minified JavaScript --> 
  <link href="style.css" rel="stylesheet">
  <script src="https://thimble.mozilla.org/resources/remix/index.js" type="text/javascript"></script>
</header>
<html>
  <body>
   ...
  </body>
</html>
```
replaced with:

```html
<!DOCTYPE html>
<header>
  <script src="https://use.fontawesome.com/e83e9b1e77.js"></script>
  <!-- Latest compiled and minified CSS --> 
  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTs
  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
  <!-- Latest compiled and minified JavaScript --> 
  <link href="style.css" rel="stylesheet">
  <script src="https://thimble.mozilla.org/resources/remix/index.js" type="text/javascript"></script>
</header>
<html>
  <head>
    <title>Untitled</title>
    <script src="http://localhost:3500/resources/remix/index.js" type="text/javascript"></script>
  </head>
  <body>
   ...
  </body>
</html>

```