### PR TITLE
Small UI Fixes

### DIFF
--- a/public/editor/scripts/project-list.js
+++ b/public/editor/scripts/project-list.js
@@ -97,9 +97,7 @@ require(["jquery", "constants", "analytics", "moment"], function($, Constants, a
         console.error("[Thimble error] Failed to delete project ", projectId, " with status: ", request.status);
       }
 
-      $project.hide({
-        duration: 250,
-        easing: "linear",
+      $project.slideToggle({
         done: function() {
           $project.remove();
         }

--- a/public/editor/stylesheets/projects-style.less
+++ b/public/editor/stylesheets/projects-style.less
@@ -52,12 +52,13 @@ h2 {
 }
 
 .delete-button {
+
+  .shared-button-styles;
+
   background-color: @red;
   display: none;
   margin-right: 10px;
   padding-left: 36px;
-
-  .shared-button-styles;
 
   img {
     height: 19px;

--- a/public/editor/stylesheets/publish.less
+++ b/public/editor/stylesheets/publish.less
@@ -210,7 +210,7 @@
     .publish-button;
 
     &:active {
-        margin-bottom: 5px;
+        margin-bottom: 2px;
     }
   }
 }

--- a/public/homepage/scripts/gallery.js
+++ b/public/homepage/scripts/gallery.js
@@ -186,7 +186,7 @@ define(["jquery", "analytics"], function($, analytics) {
           newItem.removeClass("activity-template");
           newItem.find(".thumbnail").css("background-image","url("+activity.thumbnail_url+")" );
           newItem.find(".view-project").attr("href", activity.url);
-          newItem.find(".project-title").text(activity.title);
+          newItem.find(".project-title").text(activity.title).attr("href", activity.url);
           newItem.find(".author a").text(activity.author);
           newItem.find(".author a").attr("href", activity.author_url);
           newItem.find(".description").text(activity.description);

--- a/public/homepage/stylesheets/gallery.less
+++ b/public/homepage/stylesheets/gallery.less
@@ -281,6 +281,11 @@
         line-height: 25px;
         font-weight: 600;
         text-indent: -1px;
+        cursor: pointer;
+
+        &:hover {
+          text-decoration: none;
+        }
       }
 
       .author {

--- a/public/resources/img/icon/snippets.svg
+++ b/public/resources/img/icon/snippets.svg
@@ -1,1 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21.68 12.74"><title>snippets</title><g id="Layer_2" data-name="Layer 2"><g id="Layer_1-2" data-name="Layer 1"><polygon points="12.13 0 7.38 12.73 9.77 12.73 14.51 0 12.13 0" style="fill:#fff"/><polygon points="15.16 1.2 15.16 3.75 18.81 6.39 15.16 9.38 15.16 12.02 20.98 7.5 21.68 5.72 15.16 1.2" style="fill:#fff"/><polygon points="6.4 1.2 0.65 5.19 0.58 5.24 0 7.05 6.4 12.02 6.4 9.38 2.75 6.39 6.4 3.75 6.4 1.2" style="fill:#fff"/></g></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21.68 12.74">
+  <g fill="#fff" data-name="Layer 1">
+    <path d="M12.13 0L7.38 12.73h2.39L14.51 0h-2.38M15.16 1.2v2.55l3.65 2.64-3.65 2.99v2.64l5.82-4.52.7-1.78-6.52-4.52M6.4 1.2L.65 5.19l-.07.05L0 7.05l6.4 4.97V9.38L2.75 6.39 6.4 3.75V1.2"/>
+  </g>
+</svg>

--- a/views/gallery.html
+++ b/views/gallery.html
@@ -49,7 +49,7 @@
         </div>
       </div>
       <div class='details'>
-        <h1 class='project-title'></h1>
+        <a class='project-title'></a>
         <p class='author'>{{ gettext("byAuthor") }} <a href='#'></a></p>
         <p class='description'></p>
         <div class='tags'></div>


### PR DESCRIPTION
* Corrected styling for Delete Button on Your Projects page
* Changes the visual style of how items are removed from the Your Projects page
* Titles on the homepage gallery project cards are now clickable and go to the published version of those projects
* Updated .svg file for the snippet menu icon so that it renders correctly in Firefox
* Fixes bad styling on the Update Published button that caused the contents below it to shift slightly when the button was clicked.

Fixes #2309
Fixes #2284 
Fixes #2277 
