### PR TITLE
Add webpack and convert homepage scripts to CommonJS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,10 +23,9 @@ module.exports = function( grunt ) {
             name: "editor/scripts/main"
           }, {
             name: "editor/scripts/project-list"
-          }, {
-            name: "homepage/scripts/main"
           }],
           findNestedDependencies: true,
+          fileExclusionRegExp: /^homepage/,
           optimizeCss: "none",
           removeCombined: true,
           paths: {
@@ -48,10 +47,7 @@ module.exports = function( grunt ) {
             "constants": "editor/scripts/constants",
             "EventEmitter": "../node_modules/wolfy87-eventemitter/EventEmitter.min",
             "analytics": "editor/scripts/analytics",
-            "moment": "../node_modules/moment/min/moment-with-locales.min",
-            "gallery": "homepage/scripts/gallery",
-            "getinvolved": "homepage/scripts/getinvolved",
-            "features": "homepage/scripts/features",
+            "moment": "../node_modules/moment/min/moment-with-locales.min"
           },
           shim: {
             "jquery": {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,6 +124,7 @@ module.exports = function( grunt ) {
           src: [
             "public/editor/**/*.js",
             "public/homepage/**/*.js",
+            "public/lib/**/*.js",
             "public/resources/remix/index.js",
             "!public/homepage/scripts/google-analytics.js",
             "!public/editor/scripts/google-analytics.js"

--- a/package.json
+++ b/package.json
@@ -72,19 +72,22 @@
     "time-grunt": "^1.4.0",
     "uuid": "2.0.3",
     "webmaker-i18n": "^0.3.32",
+    "webpack": "^3.2.0",
     "wolfy87-eventemitter": "^5.1.0"
   },
   "scripts": {
-    "postinstall": "grunt requirejs:dist && npm run localize && npm run localize-client",
+    "postinstall": "grunt requirejs:dist && webpack && npm run localize && npm run localize-client:webpack",
     "test": "grunt",
+    "build": "webpack",
     "client": "node scripts/watch-client",
     "server": "node app.js",
     "restart-server": "vagrant ssh -- pm2 restart thimble ; true",
     "logs": "vagrant ssh -- pm2 logs --format",
-    "prestart": "npm run localize",
+    "prestart": "npm run build && npm run localize",
     "start": "node scripts/start.js",
     "invalidate": "node scripts/invalidate.js",
     "localize": "node scripts/properties2json.js",
-    "localize-client": "node scripts/localize-client.js"
+    "localize-client": "node scripts/localize-client.js",
+    "localize-client:webpack": "node scripts/localize-client-webpack.js"
   }
 }

--- a/public/homepage/scripts/features.js
+++ b/public/homepage/scripts/features.js
@@ -1,24 +1,22 @@
-define(["jquery"], function($) {
-  var features = {
-    init: function(){
-      this.featureEls = $(".video-wrapper");
-      var that = this;
+var $ = require("jquery");
 
-      if ("ontouchstart" in document){
-        this.featureEls.bind('touchstart',function(event){
-          that.startVideo(event.currentTarget);
-        });
-      }
+module.exports = {
+  init: function(){
+    this.featureEls = $(".video-wrapper");
+    var that = this;
 
-      this.featureEls.mouseenter(function(){
-        that.startVideo($(this).get(0));
+    if ("ontouchstart" in document){
+      this.featureEls.bind('touchstart',function(event){
+        that.startVideo(event.currentTarget);
       });
-    },
-    startVideo : function(videoEl){
-      $(".video-wrapper:not(.paused)").addClass("paused").find("video").get(0).pause();
-      $(videoEl).removeClass("paused").find("video").get(0).play();
     }
-  };
 
-  return features;
-});
+    this.featureEls.mouseenter(function(){
+      that.startVideo($(this).get(0));
+    });
+  },
+  startVideo : function(videoEl){
+    $(".video-wrapper:not(.paused)").addClass("paused").find("video").get(0).pause();
+    $(videoEl).removeClass("paused").find("video").get(0).play();
+  }
+};

--- a/public/homepage/scripts/features.js
+++ b/public/homepage/scripts/features.js
@@ -1,3 +1,5 @@
+/* globals $: true */
+
 var $ = require("jquery");
 
 module.exports = {

--- a/public/homepage/scripts/gallery.js
+++ b/public/homepage/scripts/gallery.js
@@ -1,387 +1,385 @@
-define(["jquery", "analytics"], function($, analytics) {
+var $ = require("jquery");
+var analytics = require("../../editor/scripts/analytics");
 
-  var gallery = {
+module.exports = {
 
-    searchSpeedMS : 500,  // How long do we wait after a user types before searching
-    typeInterval : false, // Keeps track of if a user is typing
-    mode : "featured",    // "featured" or "search", affects the layout
-    searchTags : [],      // The selected tags that we're filtering with
-    searchTerms : [],     // Search terms from the input
-    maxDisplayTags : 5,   // Max number of tags to show above results
-    resultsTimeoutMS : 200,  // Visual delay for displaying updated results & tags
-    lastSearchString : false,
+  searchSpeedMS : 500,  // How long do we wait after a user types before searching
+  typeInterval : false, // Keeps track of if a user is typing
+  mode : "featured",    // "featured" or "search", affects the layout
+  searchTags : [],      // The selected tags that we're filtering with
+  searchTerms : [],     // Search terms from the input
+  maxDisplayTags : 5,   // Max number of tags to show above results
+  resultsTimeoutMS : 200,  // Visual delay for displaying updated results & tags
+  lastSearchString : false,
 
-    // Fetch external activity data
-    init: function() {
-      this.galleryEl = $(".gallery");
+  // Fetch external activity data
+  init: function() {
+    this.galleryEl = $(".gallery");
 
-      if(this.galleryEl.length === 0) {
+    if(this.galleryEl.length === 0) {
+      return;
+    }
+
+    var that = this;
+    var URL = "https://mozilla.github.io/thimble-homepage-gallery/activities.json";
+    $.get(URL).done(function(returnedData) {
+      that.startGallery(returnedData);
+    }).fail(function(){
+      console.log("Unable to load gallery project data from " + URL);
+      that.galleryEl.addClass("loading-error");
+      that.galleryEl.find("input").attr("disabled",true);
+    });
+  },
+
+  // Populate gallery and add UI event handlers
+  startGallery : function(activities) {
+
+    var that = this;
+    this.galleryEl.on("focus", "input",function(){ that.updateUI(); });
+    this.galleryEl.on("blur", "input",function(){ that.updateUI(); });
+
+    this.galleryEl.on("click",".clear",function(){ that.clearSearch(); });
+    this.galleryEl.on("keydown",".search",function(e){ that.keyPressed(e); });
+    this.galleryEl.on("mousedown",".tag",function(){  that.tagClicked($(this).attr("tag")); });
+
+    this.galleryEl.on("click",".activity .view-project",function(){ that.thumbnailClicked($(this)); });
+    this.galleryEl.on("click",".activity .remix",function(){ that.remixClicked($(this)); });
+
+    this.galleryEl.on("click",".search-tags .remove",function(){ that.removeTag($(this).parent()); });
+    this.galleryEl.on("click",".start-over",function(e){ that.startOver(e); });
+
+    this.activities = activities;
+    this.filterActivities();
+
+    setTimeout(function(){
+      that.galleryEl.removeClass("loading");
+    }, this.resultsTimeoutMS);
+  },
+
+  //When a Project preview gets clicked
+  thumbnailClicked: function(el){
+    var title = el.closest(".activity").find(".project-title").text();
+    analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Gallery Project Viewed", label : title });
+  },
+
+  //When a Project gets remixed
+  remixClicked: function(el){
+    var title = el.closest(".activity").find(".project-title").text();
+    analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Gallery Project Remixed", label : title });
+  },
+
+  // Removes one of the tags that is currently being used as a filter
+  removeTag : function(tagEl) {
+    var tagName = tagEl.attr("tag");
+    var index = this.searchTags.indexOf(tagName);
+    if(index > -1) {
+      this.searchTags.splice(index,1);
+    }
+    tagEl.remove();
+    this.filterActivities();
+    this.updateUI();
+  },
+
+  // Fires whenever someone types into the search field
+  keyPressed : function(e) {
+    clearTimeout(this.typeInterval);
+    var that = this;
+
+    // Removes the last-added search tag if a user presses backspace and
+    // there is no search term
+    if(this.galleryEl.find(".search").val().length === 0 && e.keyCode === 8) {
+      var tagNum = this.galleryEl.find(".search-tags .search-tag").length;
+      if(tagNum > 0) {
+        this.removeTag(this.galleryEl.find(".search-tag:last-child"));
         return;
       }
+    }
 
-      var that = this;
-      var URL = "https://mozilla.github.io/thimble-homepage-gallery/activities.json";
-      $.get(URL).done(function(returnedData) {
-        that.startGallery(returnedData);
-      }).fail(function(){
-        console.log("Unable to load gallery project data from " + URL);
-        that.galleryEl.addClass("loading-error");
-        that.galleryEl.find("input").attr("disabled",true);
-      });
-    },
+    this.typeInterval = setTimeout(function(){
+      that.updateUI();
+      that.filterActivities();
+    }, that.searchSpeedMS);
+  },
 
-    // Populate gallery and add UI event handlers
-    startGallery : function(activities) {
+  // Determines which activities should be displayed
+  filterActivities : function(){
+    if(this.galleryEl.find('input').val().length > 0 || this.searchTags.length > 0) {
+      this.mode = "search";
+    } else {
+      this.mode = "featured";
+    }
 
-      var that = this;
-      this.galleryEl.on("focus", "input",function(){ that.updateUI(); });
-      this.galleryEl.on("blur", "input",function(){ that.updateUI(); });
-
-      this.galleryEl.on("click",".clear",function(){ that.clearSearch(); });
-      this.galleryEl.on("keydown",".search",function(e){ that.keyPressed(e); });
-      this.galleryEl.on("mousedown",".tag",function(){  that.tagClicked($(this).attr("tag")); });
-
-      this.galleryEl.on("click",".activity .view-project",function(){ that.thumbnailClicked($(this)); });
-      this.galleryEl.on("click",".activity .remix",function(){ that.remixClicked($(this)); });
-
-      this.galleryEl.on("click",".search-tags .remove",function(){ that.removeTag($(this).parent()); });
-      this.galleryEl.on("click",".start-over",function(e){ that.startOver(e); });
-
-      this.activities = activities;
-      this.filterActivities();
-
-      setTimeout(function(){
-        that.galleryEl.removeClass("loading");
-      }, this.resultsTimeoutMS);
-    },
-
-    //When a Project preview gets clicked
-    thumbnailClicked: function(el){
-      var title = el.closest(".activity").find(".project-title").text();
-      analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Gallery Project Viewed", label : title });
-    },
-
-    //When a Project gets remixed
-    remixClicked: function(el){
-      var title = el.closest(".activity").find(".project-title").text();
-      analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Gallery Project Remixed", label : title });
-    },
-
-    // Removes one of the tags that is currently being used as a filter
-    removeTag : function(tagEl) {
-      var tagName = tagEl.attr("tag");
-      var index = this.searchTags.indexOf(tagName);
-      if(index > -1) {
-        this.searchTags.splice(index,1);
-      }
-      tagEl.remove();
-      this.filterActivities();
-      this.updateUI();
-    },
-
-    // Fires whenever someone types into the search field
-    keyPressed : function(e) {
-      clearTimeout(this.typeInterval);
-      var that = this;
-
-      // Removes the last-added search tag if a user presses backspace and
-      // there is no search term
-      if(this.galleryEl.find(".search").val().length === 0 && e.keyCode === 8) {
-        var tagNum = this.galleryEl.find(".search-tags .search-tag").length;
-        if(tagNum > 0) {
-          this.removeTag(this.galleryEl.find(".search-tag:last-child"));
-          return;
+    // If there is no search term, shows the featured activities only
+    if(this.mode === "featured") {
+      for(var i = 0; i < this.activities.length; i++) {
+        var activity = this.activities[i];
+        if(activity.featured) {
+          activity.display = true;
+        } else {
+          activity.display = false;
         }
       }
+    }
 
-      this.typeInterval = setTimeout(function(){
-        that.updateUI();
-        that.filterActivities();
-      }, that.searchSpeedMS);
-    },
+    // Checks for the search term in the title, description  and tags
+    if(this.mode === "search") {
 
-    // Determines which activities should be displayed
-    filterActivities : function(){
-      if(this.galleryEl.find('input').val().length > 0 || this.searchTags.length > 0) {
-        this.mode = "search";
-      } else {
-        this.mode = "featured";
-      }
+      this.searchTerms = this.galleryEl.find("input").val().toLowerCase().split(" ");
 
-      // If there is no search term, shows the featured activities only
-      if(this.mode === "featured") {
-        for(var i = 0; i < this.activities.length; i++) {
-          var activity = this.activities[i];
-          if(activity.featured) {
-            activity.display = true;
-          } else {
+      for(var i = 0; i < this.activities.length; i++) {
+        var activity = this.activities[i];
+        var searchString = activity.title + activity.description + activity.tags + activity.author;
+        searchString = searchString.toLowerCase();
+
+        activity.display = true;
+
+        // Check for each of the selected tags...
+        for(var j = 0; j < this.searchTags.length; j++) {
+          var thisTerm = this.searchTags[j];
+          if(searchString.indexOf(thisTerm) < 0) {
+            activity.display = false;
+          }
+        }
+
+        // Check for each of the search terms...
+        for(var j = 0; j < this.searchTerms.length; j++) {
+          var thisTerm = this.searchTerms[j];
+          if(searchString.indexOf(thisTerm) < 0) {
             activity.display = false;
           }
         }
       }
-
-      // Checks for the search term in the title, description  and tags
-      if(this.mode === "search") {
-
-        this.searchTerms = this.galleryEl.find("input").val().toLowerCase().split(" ");
-
-        for(var i = 0; i < this.activities.length; i++) {
-          var activity = this.activities[i];
-          var searchString = activity.title + activity.description + activity.tags + activity.author;
-          searchString = searchString.toLowerCase();
-
-          activity.display = true;
-
-          // Check for each of the selected tags...
-          for(var j = 0; j < this.searchTags.length; j++) {
-            var thisTerm = this.searchTags[j];
-            if(searchString.indexOf(thisTerm) < 0) {
-              activity.display = false;
-            }
-          }
-
-          // Check for each of the search terms...
-          for(var j = 0; j < this.searchTerms.length; j++) {
-            var thisTerm = this.searchTerms[j];
-            if(searchString.indexOf(thisTerm) < 0) {
-              activity.display = false;
-            }
-          }
-        }
-      }
-
-      // Send analytics event
-      var searchQuery = this.searchTerms.join(" ");
-      if(searchQuery.length > 0 && searchQuery != this.lastSearchString) {
-        analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Keyword Search", label : searchQuery });
-      }
-      this.lastSearchString = searchQuery;
-
-      this.galleryEl.find(".popular-tags, .activities").addClass("fade");
-      this.updateUI();
-
-      var that = this;
-
-      setTimeout(function(){
-        that.displayActivities(that.activities);
-      },this.resultsTimeoutMS);
-
-      setTimeout(function(){
-        that.galleryEl.find(".fade").removeClass("fade");
-      },this.resultsTimeoutMS * 2);
-    },
-
-    // Adds all of the items that are supposed to be shown to the page
-    displayActivities: function(activities){
-      this.galleryEl.find(".activities *").remove();
-
-      var resultCount = 0;
-
-      for(var i = 0; i < activities.length; i++) {
-        var activity = activities[i];
-
-        if(activity.display) {
-          resultCount++;
-          var newItem = this.galleryEl.find(".activity-template").clone();
-          newItem.removeClass("activity-template");
-          newItem.find(".thumbnail").css("background-image","url("+activity.thumbnail_url+")" );
-          newItem.find(".view-project").attr("href", activity.url);
-          newItem.find(".project-title").text(activity.title).attr("href", activity.url);
-          newItem.find(".author a").text(activity.author);
-          newItem.find(".author a").attr("href", activity.author_url);
-          newItem.find(".description").text(activity.description);
-
-          newItem.find(".remix").attr("href", "/projects/" + activity.project_id + "/remix");
-          if(activity.teaching_kit_url) {
-            newItem.find(".teaching-kit").attr("href", activity.teaching_kit_url).removeClass("hidden");
-          } else {
-            newItem.find(".teaching-kit").addClass("hidden");
-          }
-
-          for(var j = 0; j < activity.tags.length; j++) {
-            newItem.find(".tags").append("<a class='tag' tag='"+activity.tags[j]+"' title='See other projects tagged " + activity.tags[j] + "' >" + activity.tags[j] + "</a> ");
-          }
-
-          this.galleryEl.find(".activities").append(newItem);
-        }
-      }
-    },
-
-    // Displays the list of tags under the search bar
-    displayTags: function(type){
-
-      this.galleryEl.find(".tag-list .tag").remove();
-
-      var tags = {};
-
-      for(var i = 0; i < this.activities.length; i++) {
-        var activity = this.activities[i];
-        if(type === "featured" || activity.display) {
-          for(var j = 0; j < activity.tags.length; j++) {
-            var tag = activity.tags[j];
-            if(!tags[tag]) {
-              tags[tag] = 1;
-            } else {
-              tags[tag]++;
-            }
-          }
-        }
-      }
-
-      var tagsArray = [];
-
-      for(var k in tags) {
-        if (tags.hasOwnProperty(k)) {
-          var push = false;
-          for(var i = this.searchTags.length; i >= 0; i--) {
-            if(this.searchTags.indexOf(k) < 0) {
-              push = true;
-            }
-          }
-          if(push) {
-            tagsArray.push([k, tags[k]]);
-          }
-        }
-      }
-
-      tagsArray.sort(function(x,y){
-        return y[1] - x[1];
-      });
-
-      var maxTags = this.maxDisplayTags;
-
-      if(maxTags > tagsArray.length) {
-        maxTags = tagsArray.length;
-      }
-
-      for(var i = 0; i < maxTags; i++) {
-        var tag = tagsArray[i];
-        this.galleryEl.find(".tag-list").append("<a class='tag' tag='"+tag[0]+"' title='Search for projects tagged " + tag[0] + "'>" + tag[0] + " <span class='count'>" + tag[1] + "<span></a>");
-      }
-
-      var tagsTitleEl = this.galleryEl.find(".popular-tags .tags-title");
-
-      if(type === "featured") {
-        tagsTitleEl.text("{{ popularTags }}");
-      } else {
-        tagsTitleEl.text("{{ addFilter }}");
-      }
-
-      if(maxTags > 0) {
-        tagsTitleEl.show();
-      } else {
-        tagsTitleEl.hide();
-      }
-    },
-
-    // Handles when a popular tag, or a tag on an activity is clicked
-    tagClicked : function(term) {
-
-      if(this.searchTags.indexOf(term) < 0) {
-        this.galleryEl.find(".search-tags").append("<span tag='"+term+"'class='search-tag'>" + term + "<a class='remove'></a></span>");
-        this.searchTags.push(term);
-        this.filterActivities();
-      }
-
-      this.galleryEl.find(".search-wrapper").addClass("pop");
-
-      var that = this;
-      setTimeout(function(){
-        that.galleryEl.find(".search-wrapper").removeClass("pop");
-      },200);
-
-      analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Gallery Tag Clicked", label : term });
-    },
-
-    // Updates the tags & activities UI
-    updateResultsUI : function() {
-      var displaycount = 0;
-      for(var i = 0; i < this.activities.length; i++) {
-        var activity = this.activities[i];
-        if(activity.display) {
-          displaycount++;
-        }
-      }
-
-      if(displaycount > 1) {
-        this.galleryEl.find(".popular-tags").removeClass("hidden");
-      } else {
-        this.galleryEl.find(".popular-tags").addClass("hidden");
-      }
-
-      if(this.mode === "featured" || displaycount === 0) {
-        this.displayTags("featured");
-      } else {
-        this.displayTags("search");
-      }
-    },
-
-    // Updates the search and results title UI
-    updateUI : function() {
-      var displaycount = 0;
-
-      for(var i = 0; i < this.activities.length; i++) {
-        var activity = this.activities[i];
-        if(activity.display) {
-          displaycount++;
-        }
-      }
-
-      if(displaycount === 0) {
-        this.galleryEl.addClass("no-results-found");
-      } else {
-        this.galleryEl.removeClass("no-results-found");
-      }
-
-      if(this.mode === "search") {
-        this.galleryEl.find(".title").text("{{ searchResultsTitle }}");
-      } else {
-        this.galleryEl.find(".title").text("{{ remixGalleryTitle }}");
-      }
-
-      var termLength = $(".search").val().length;
-      if(termLength > 0) {
-        this.galleryEl.addClass("has-term");
-      } else {
-        this.galleryEl.removeClass("has-term");
-      }
-
-      var active = false;
-
-      if(termLength > 0 ) { active = true; }
-      if(this.galleryEl.find("input").is(":focus")) { active = true; }
-      if(this.searchTags.length > 0) { active = true; }
-
-      if(active) {
-        this.galleryEl.attr("active",true);
-      } else {
-        this.galleryEl.removeAttr("active");
-      }
-
-      var that = this;
-      setTimeout(function(){
-        that.updateResultsUI();
-      },this.resultsTimeoutMS);
-
-    },
-
-    // Resets the search field and tags
-    startOver : function(e){
-      this.galleryEl.find(".search").val("");
-      this.searchTags = [];
-      this.searchTerms = [];
-      this.galleryEl.find(".search-tags *").remove();
-      this.filterActivities();
-      e.preventDefault();
-    },
-
-    // Clears the search field
-    clearSearch : function() {
-      this.galleryEl.find(".search").val("");
-      this.filterActivities();
-      this.updateUI();
     }
-  };
 
-  return gallery;
-});
+    // Send analytics event
+    var searchQuery = this.searchTerms.join(" ");
+    if(searchQuery.length > 0 && searchQuery != this.lastSearchString) {
+      analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Keyword Search", label : searchQuery });
+    }
+    this.lastSearchString = searchQuery;
+
+    this.galleryEl.find(".popular-tags, .activities").addClass("fade");
+    this.updateUI();
+
+    var that = this;
+
+    setTimeout(function(){
+      that.displayActivities(that.activities);
+    },this.resultsTimeoutMS);
+
+    setTimeout(function(){
+      that.galleryEl.find(".fade").removeClass("fade");
+    },this.resultsTimeoutMS * 2);
+  },
+
+  // Adds all of the items that are supposed to be shown to the page
+  displayActivities: function(activities){
+    this.galleryEl.find(".activities *").remove();
+
+    var resultCount = 0;
+
+    for(var i = 0; i < activities.length; i++) {
+      var activity = activities[i];
+
+      if(activity.display) {
+        resultCount++;
+        var newItem = this.galleryEl.find(".activity-template").clone();
+        newItem.removeClass("activity-template");
+        newItem.find(".thumbnail").css("background-image","url("+activity.thumbnail_url+")" );
+        newItem.find(".view-project").attr("href", activity.url);
+        newItem.find(".project-title").text(activity.title).attr("href", activity.url);
+        newItem.find(".author a").text(activity.author);
+        newItem.find(".author a").attr("href", activity.author_url);
+        newItem.find(".description").text(activity.description);
+
+        newItem.find(".remix").attr("href", "/projects/" + activity.project_id + "/remix");
+        if(activity.teaching_kit_url) {
+          newItem.find(".teaching-kit").attr("href", activity.teaching_kit_url).removeClass("hidden");
+        } else {
+          newItem.find(".teaching-kit").addClass("hidden");
+        }
+
+        for(var j = 0; j < activity.tags.length; j++) {
+          newItem.find(".tags").append("<a class='tag' tag='"+activity.tags[j]+"' title='See other projects tagged " + activity.tags[j] + "' >" + activity.tags[j] + "</a> ");
+        }
+
+        this.galleryEl.find(".activities").append(newItem);
+      }
+    }
+  },
+
+  // Displays the list of tags under the search bar
+  displayTags: function(type){
+
+    this.galleryEl.find(".tag-list .tag").remove();
+
+    var tags = {};
+
+    for(var i = 0; i < this.activities.length; i++) {
+      var activity = this.activities[i];
+      if(type === "featured" || activity.display) {
+        for(var j = 0; j < activity.tags.length; j++) {
+          var tag = activity.tags[j];
+          if(!tags[tag]) {
+            tags[tag] = 1;
+          } else {
+            tags[tag]++;
+          }
+        }
+      }
+    }
+
+    var tagsArray = [];
+
+    for(var k in tags) {
+      if (tags.hasOwnProperty(k)) {
+        var push = false;
+        for(var i = this.searchTags.length; i >= 0; i--) {
+          if(this.searchTags.indexOf(k) < 0) {
+            push = true;
+          }
+        }
+        if(push) {
+          tagsArray.push([k, tags[k]]);
+        }
+      }
+    }
+
+    tagsArray.sort(function(x,y){
+      return y[1] - x[1];
+    });
+
+    var maxTags = this.maxDisplayTags;
+
+    if(maxTags > tagsArray.length) {
+      maxTags = tagsArray.length;
+    }
+
+    for(var i = 0; i < maxTags; i++) {
+      var tag = tagsArray[i];
+      this.galleryEl.find(".tag-list").append("<a class='tag' tag='"+tag[0]+"' title='Search for projects tagged " + tag[0] + "'>" + tag[0] + " <span class='count'>" + tag[1] + "<span></a>");
+    }
+
+    var tagsTitleEl = this.galleryEl.find(".popular-tags .tags-title");
+
+    if(type === "featured") {
+      tagsTitleEl.text("{{ popularTags }}");
+    } else {
+      tagsTitleEl.text("{{ addFilter }}");
+    }
+
+    if(maxTags > 0) {
+      tagsTitleEl.show();
+    } else {
+      tagsTitleEl.hide();
+    }
+  },
+
+  // Handles when a popular tag, or a tag on an activity is clicked
+  tagClicked : function(term) {
+
+    if(this.searchTags.indexOf(term) < 0) {
+      this.galleryEl.find(".search-tags").append("<span tag='"+term+"'class='search-tag'>" + term + "<a class='remove'></a></span>");
+      this.searchTags.push(term);
+      this.filterActivities();
+    }
+
+    this.galleryEl.find(".search-wrapper").addClass("pop");
+
+    var that = this;
+    setTimeout(function(){
+      that.galleryEl.find(".search-wrapper").removeClass("pop");
+    },200);
+
+    analytics.event({ category : analytics.eventCategories.HOMEPAGE, action : "Gallery Tag Clicked", label : term });
+  },
+
+  // Updates the tags & activities UI
+  updateResultsUI : function() {
+    var displaycount = 0;
+    for(var i = 0; i < this.activities.length; i++) {
+      var activity = this.activities[i];
+      if(activity.display) {
+        displaycount++;
+      }
+    }
+
+    if(displaycount > 1) {
+      this.galleryEl.find(".popular-tags").removeClass("hidden");
+    } else {
+      this.galleryEl.find(".popular-tags").addClass("hidden");
+    }
+
+    if(this.mode === "featured" || displaycount === 0) {
+      this.displayTags("featured");
+    } else {
+      this.displayTags("search");
+    }
+  },
+
+  // Updates the search and results title UI
+  updateUI : function() {
+    var displaycount = 0;
+
+    for(var i = 0; i < this.activities.length; i++) {
+      var activity = this.activities[i];
+      if(activity.display) {
+        displaycount++;
+      }
+    }
+
+    if(displaycount === 0) {
+      this.galleryEl.addClass("no-results-found");
+    } else {
+      this.galleryEl.removeClass("no-results-found");
+    }
+
+    if(this.mode === "search") {
+      this.galleryEl.find(".title").text("{{ searchResultsTitle }}");
+    } else {
+      this.galleryEl.find(".title").text("{{ remixGalleryTitle }}");
+    }
+
+    var termLength = $(".search").val().length;
+    if(termLength > 0) {
+      this.galleryEl.addClass("has-term");
+    } else {
+      this.galleryEl.removeClass("has-term");
+    }
+
+    var active = false;
+
+    if(termLength > 0 ) { active = true; }
+    if(this.galleryEl.find("input").is(":focus")) { active = true; }
+    if(this.searchTags.length > 0) { active = true; }
+
+    if(active) {
+      this.galleryEl.attr("active",true);
+    } else {
+      this.galleryEl.removeAttr("active");
+    }
+
+    var that = this;
+    setTimeout(function(){
+      that.updateResultsUI();
+    },this.resultsTimeoutMS);
+
+  },
+
+  // Resets the search field and tags
+  startOver : function(e){
+    this.galleryEl.find(".search").val("");
+    this.searchTags = [];
+    this.searchTerms = [];
+    this.galleryEl.find(".search-tags *").remove();
+    this.filterActivities();
+    e.preventDefault();
+  },
+
+  // Clears the search field
+  clearSearch : function() {
+    this.galleryEl.find(".search").val("");
+    this.filterActivities();
+    this.updateUI();
+  }
+};

--- a/public/homepage/scripts/gallery.js
+++ b/public/homepage/scripts/gallery.js
@@ -1,3 +1,5 @@
+/* globals $: true */
+
 var $ = require("jquery");
 var analytics = require("../../editor/scripts/analytics");
 

--- a/public/homepage/scripts/getinvolved.js
+++ b/public/homepage/scripts/getinvolved.js
@@ -1,3 +1,5 @@
+/* globals $: true */
+
 var $ = require("jquery");
 
 module.exports = {

--- a/public/homepage/scripts/getinvolved.js
+++ b/public/homepage/scripts/getinvolved.js
@@ -1,36 +1,33 @@
-define(["jquery"], function($) {
+var $ = require("jquery");
 
-  var issues = {
-    init: function(){
-      this.issueCountEl = $(".good-bug-count");
+module.exports = {
+  init: function(){
+    this.issueCountEl = $(".good-bug-count");
 
-      if(this.issueCountEl.length === 0) {
-        return;
-      }
-
-      var URL = "https://api.github.com/repos/mozilla/thimble.mozilla.org/issues?labels=good%20first%20bug";
-
-      var that = this;
-      $.ajax({
-        url: URL,
-        complete: function(xhr) {
-          that.updateCount(xhr.responseJSON);
-        }
-      });
-
-    },
-    updateCount: function(data){
-      var issueCount = data.length;
-
-      if(issueCount > 1) {
-        if(issueCount >= 30) {
-          issueCount = "30+";
-        }
-        this.issueCountEl.text(issueCount);
-        this.issueCountEl.show();
-      }
+    if(this.issueCountEl.length === 0) {
+      return;
     }
-  };
 
-  return issues;
-});
+    var URL = "https://api.github.com/repos/mozilla/thimble.mozilla.org/issues?labels=good%20first%20bug";
+
+    var that = this;
+    $.ajax({
+      url: URL,
+      complete: function(xhr) {
+        that.updateCount(xhr.responseJSON);
+      }
+    });
+
+  },
+  updateCount: function(data){
+    var issueCount = data.length;
+
+    if(issueCount > 1) {
+      if(issueCount >= 30) {
+        issueCount = "30+";
+      }
+      this.issueCountEl.text(issueCount);
+      this.issueCountEl.show();
+    }
+  }
+};

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -1,29 +1,14 @@
-/* global require */
-require.config({
-  waitSeconds: 120,
-  baseUrl: "/{{ locale }}/homepage/scripts",
-  paths: {
-    "jquery": "/node_modules/jquery/dist/jquery.min",
-    "localized": "/node_modules/webmaker-i18n/localized",
-    "uuid": "/node_modules/node-uuid/uuid",
-    "cookies": "/node_modules/cookies-js/dist/cookies",
-    "analytics": "/{{ locale }}/editor/scripts/analytics",
-    "gallery": "/{{ locale }}/homepage/scripts/gallery",
-    "features": "/{{ locale }}/homepage/scripts/features",
-    "getinvolved": "/{{ locale }}/homepage/scripts/getinvolved",
-    // TODO: we should really put the homepage and editor in the same scope for code sharing
-    "fc/bramble-popupmenu": "/{{ locale }}/editor/scripts/editor/js/fc/bramble-popupmenu",
-    "fc/bramble-keyhandler": "/{{ locale }}/editor/scripts/editor/js/fc/bramble-keyhandler",
-    "fc/bramble-underlay": "/{{ locale }}/editor/scripts/editor/js/fc/bramble-underlay"
-  },
-  shim: {
-    "jquery": {
-      exports: "$"
-    }
-  }
-});
+var $ = require("jquery");
+var uuid = require("uuid");
+var cookies = require("cookies-js");
 
-function setupNewProjectLinks($, analytics) {
+var features = require("./features");
+var gallery = require("./gallery");
+var getinvolved = require("./getinvolved");
+var analytics = require("../../editor/scripts/analytics");
+var PopupMenu = require("../../lib/popupmenu");
+
+function setupNewProjectLinks() {
   var authenticated = $("#navbar-login").hasClass("signed-in");
   var newProjectButton = $("#new-project-button");
   var locale = $("html")[0].lang;
@@ -57,7 +42,7 @@ function setupNewProjectLinks($, analytics) {
   newProjectButton.one("click", newProjectClickHandler);
 }
 
-function setupAuthentication($, uuid, cookies, analytics) {
+function setupAuthentication() {
   var joinEl = $('#signup-link');
   var loginEl = $('#login-link');
   var loginUrl = loginEl.attr("data-loginUrl");
@@ -94,14 +79,12 @@ function setupAuthentication($, uuid, cookies, analytics) {
 // flow. If more needs to be added, the logic should be factored out into
 // separate modules, each of which would be initialized here.
 // See: public/editor/scripts/main.js
-function init($, uuid, cookies, PopupMenu, analytics, gallery, getinvolved,features) {
+$(function init() {
   PopupMenu.create("#navbar-logged-in .dropdown-toggle", "#navbar-logged-in .dropdown-content");
   PopupMenu.create("#navbar-locale .dropdown-toggle", "#navbar-locale .dropdown-content");
-  setupAuthentication($, uuid, cookies, analytics);
-  setupNewProjectLinks($, analytics);
+  setupAuthentication();
+  setupNewProjectLinks();
   gallery.init();
   features.init();
   getinvolved.init();
-}
-
-require(['jquery', 'uuid', 'cookies', 'fc/bramble-popupmenu', 'analytics', 'gallery', 'getinvolved','features'], init);
+});

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -1,3 +1,5 @@
+/* globals $: true */
+
 var $ = require("jquery");
 var uuid = require("uuid");
 var cookies = require("cookies-js");

--- a/public/lib/keyhandler.js
+++ b/public/lib/keyhandler.js
@@ -1,3 +1,5 @@
+/* globals $: true */
+
 var $ = require("jquery");
 
 // Run the given function `fn` when the key with `keyCode` is pressed down

--- a/public/lib/keyhandler.js
+++ b/public/lib/keyhandler.js
@@ -1,0 +1,62 @@
+var $ = require("jquery");
+
+// Run the given function `fn` when the key with `keyCode` is pressed down
+function KeyHandler(keyCode, elem, fn) {
+
+  if(typeof keyCode !== "number") {
+    fn = elem;
+    elem = keyCode;
+    keyCode = null;
+  }
+
+  function handler(e) {
+    if(!keyCode) {
+      return fn(e);
+    }
+
+    if(e.which !== keyCode) {
+      return;
+    }
+
+    e.stopPropagation();
+    e.preventDefault();
+    fn(e);
+  }
+
+  if(typeof elem === "function") {
+    fn = elem;
+    elem = document;
+  }
+
+  $(elem).on("keyup", handler);
+
+  this.stop = function() {
+    $(elem).off("keyup", handler);
+  };
+}
+
+// Helper for ESC key handling
+function EscKeyHandler(elem, fn) {
+  KeyHandler.call(this, 27, elem, fn);
+}
+EscKeyHandler.prototype = KeyHandler.prototype;
+EscKeyHandler.prototype.constructor = EscKeyHandler;
+KeyHandler.ESC = EscKeyHandler;
+
+// Helper for Enter key handling
+function EnterKeyHandler(elem, fn) {
+  KeyHandler.call(this, 13, elem, fn);
+}
+EnterKeyHandler.prototype = KeyHandler.prototype;
+EnterKeyHandler.prototype.constructor = EnterKeyHandler;
+KeyHandler.Enter = EnterKeyHandler;
+
+// Helper for any key being pressed to check the title length
+function AnyKeyHandler(elem, fn) {
+  KeyHandler.call(this, elem, fn);
+}
+AnyKeyHandler.prototype = KeyHandler.prototype;
+AnyKeyHandler.prototype.constructor = AnyKeyHandler;
+KeyHandler.Any = AnyKeyHandler;
+
+module.exports = KeyHandler;

--- a/public/lib/popupmenu.js
+++ b/public/lib/popupmenu.js
@@ -1,0 +1,89 @@
+var $ = require("jquery");
+var KeyHandler = require("./keyhandler");
+var Underlay = require("./underlay");
+
+function PopupMenu(button, menu, applyOffset) {
+  var self = this;
+  self._button$ = $(button);
+  self._menu$ = $(menu);
+
+  // If we want the menu offset as a "bubble" we need to apply it
+  if(applyOffset) {
+    self.applyOffset = function() {
+      // Determine where to horizontally place menu based on button's icon location
+      var menuWidth = self._menu$.width();
+      var iconWidth = self._button$.width();
+      var leftOffset = self._button$.offset().left - menuWidth/2 + iconWidth/2;
+      var arrowOffset = menuWidth/2 - iconWidth/2;
+      if(leftOffset < 0) {
+        arrowOffset = menuWidth/2 - iconWidth/2 + leftOffset;
+        leftOffset = 0;
+      }
+      self._menu$.find(".arrow-tip").css("left", arrowOffset);
+      self._menu$.css("left", leftOffset);
+    };
+  }
+
+  self.close = function(e) {
+    if(e) {
+      e.stopPropagation();
+      self._button$.removeClass('active');
+    }
+    if(!self.showing) {
+      return;
+    }
+
+    $(window).off("resize", self.close);
+    self._button$.closest(".dropdown").removeClass("expanded");
+
+    self._menu$.hide();
+
+    if(self._underlay) {
+      self._underlay.remove();
+      self._underlay = null;
+    }
+
+    if(self._escKeyHandler) {
+      self._escKeyHandler.stop();
+      self._escKeyHandler = null;
+    }
+
+    delete self.showing;
+  };
+
+  // Toggle the menu on/off when the button is clicked.
+  self._button$.on("click", function(e) {
+    e.stopPropagation();
+
+    if(!self.showing) {
+      self._button$.addClass('active');
+      self.show();
+    } else {
+      self.close();
+    }
+  });
+}
+PopupMenu.create = function(button, menu) {
+  return new PopupMenu(button, menu);
+};
+PopupMenu.createWithOffset = function(button, menu) {
+  return new PopupMenu(button, menu, true);
+};
+PopupMenu.prototype.show = function() {
+  var self = this;
+
+  if(self.applyOffset) {
+    self.applyOffset();
+  }
+
+  self._menu$.show();
+  self._underlay = new Underlay(self._menu$, self.close);
+  self._escKeyHandler = new KeyHandler.ESC(self.close);
+  self._button$.closest(".dropdown").addClass("expanded");
+  // Close on resize
+  $(window).on("resize", self.close);
+
+  self.showing = true;
+};
+
+module.exports = PopupMenu;

--- a/public/lib/popupmenu.js
+++ b/public/lib/popupmenu.js
@@ -1,3 +1,5 @@
+/* globals $: true */
+
 var $ = require("jquery");
 var KeyHandler = require("./keyhandler");
 var Underlay = require("./underlay");

--- a/public/lib/underlay.js
+++ b/public/lib/underlay.js
@@ -1,0 +1,16 @@
+var $ = require("jquery");
+
+// Manage a transparent div to capture mouse clicks over the iframe
+function Underlay(parent, onclick) {
+  this._onclick = onclick;
+
+  var underlay$ = this._underlay$ = $("<div class=click-underlay></div>");
+  $(parent).after(underlay$);
+  underlay$.on("click", onclick);
+}
+Underlay.prototype.remove = function() {
+  this._underlay$.off("click", this._onclick);
+  this._underlay$.remove();
+};
+
+module.exports = Underlay;

--- a/public/lib/underlay.js
+++ b/public/lib/underlay.js
@@ -1,3 +1,5 @@
+/* globals $: true */
+
 var $ = require("jquery");
 
 // Manage a transparent div to capture mouse clicks over the iframe

--- a/scripts/localize-client-webpack.js
+++ b/scripts/localize-client-webpack.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const path = require("path");
+
+const localizeClient = require("./localize-client");
+
+localizeClient.runAll((currentPath, stats) => {
+  // Ignore the homepage dir so that we can localize it separately
+  // See https://github.com/kriskowal/q-io#listtreepath-guardpath-stat
+  if(path.basename(currentPath) === "homepage") {
+    return null;
+  }
+
+  return true;
+})
+.then(() => {
+  // Now we localize the homepage dir
+  const srcPath = path.join(process.cwd(), "dist");
+
+  return localizeClient.localizeClientFiles(srcPath, (currentPath, stats) => {
+    const relPath = path.relative(srcPath, currentPath);
+
+    if(relPath.indexOf("homepage") === 0 || currentPath === srcPath) {
+      return true;
+    }
+
+    return null;
+  })
+  .then(() => console.log("Successfully localized the client[webpack]"))
+  .catch(err => console.error("Failed to generate localized client[webpack] with: ", err));
+});

--- a/scripts/localize-client.js
+++ b/scripts/localize-client.js
@@ -18,9 +18,7 @@ let strings = {
 };
 strings.en_US.locale = "en_US";
 
-function makeLocalizedCopy(locale, srcPath, template) {
-  let destPath = path.join(dest, locale, path.relative(src, srcPath));
-
+function makeLocalizedCopy(locale, srcPath, destPath, template) {
   return fs.makeTree(path.dirname(destPath))
   .then(() => {
     return new Promise((resolve, reject) => {
@@ -37,7 +35,7 @@ function makeLocalizedCopy(locale, srcPath, template) {
   });
 }
 
-function localizeFile(filePath) {
+function localizeFile(filePath, filePathRelToSrc) {
   let isJS = path.extname(filePath) === ".js";
   if(!isJS) {
     return Promise.resolve();
@@ -45,11 +43,17 @@ function localizeFile(filePath) {
 
   let template = nunjucks.configure(filePath, { noCache: true });
 
-  return Promise.all(locales.map(locale => makeLocalizedCopy(locale, filePath, template)));
+  return Promise.all(locales.map(locale => {
+    let destPath = path.join(dest, locale, filePathRelToSrc);
+
+    return makeLocalizedCopy(locale, filePath, destPath, template);
+  }));
 }
 
-function localizeClientFiles() {
-  return fs.listTree(src)
+function localizeClientFiles(srcPath, ignoreL10nForDir) {
+  srcPath = srcPath || src;
+
+  return fs.listTree(srcPath, ignoreL10nForDir)
   .then(nodePaths => Promise.all(nodePaths.map(nodePath => {
     return fs.stat(nodePath)
     .then(stats => {
@@ -57,7 +61,7 @@ function localizeClientFiles() {
         return;
       }
 
-      return localizeFile(nodePath);
+      return localizeFile(nodePath, path.relative(srcPath, nodePath));
     });
   })));
 }
@@ -98,19 +102,24 @@ function readLocaleStrings(localeList) {
   });
 }
 
-if(require.main === module) {
-  getListLocales(localeDir)
+function runAll(ignoreL10nForDir) {
+  return getListLocales(localeDir)
   .then(readLocaleStrings)
   .then(cleanupOldClient)
   .then(createClientLocaleDirectories)
-  .then(localizeClientFiles)
+  .then(() => localizeClientFiles(src, ignoreL10nForDir))
   .then(() => console.log("Successfully localized the client at: ", dest))
   .catch((err) => console.error("Failed to generate localized client with: ", err));
+}
+
+if(require.main === module) {
+  return runAll();
 }
 
 module.exports = {
   readLocaleStrings,
   localizeClientFiles,
   localizeFile,
-  makeLocalizedCopy
+  makeLocalizedCopy,
+  runAll
 };

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -3,7 +3,7 @@
 let runAll = require("npm-run-all");
 let env = require("../server/lib/environment");
 
-let tasks = [ "localize-client" ];
+let tasks = [ "localize-client:webpack" ];
 let options = {
   stdout: process.stdout,
   stderr: process.stderr

--- a/views/homepage/base.html
+++ b/views/homepage/base.html
@@ -56,8 +56,7 @@
       <script src="https://pontoon.mozilla.org/pontoon.js"></script>
 
       <script id="homepage-script"
-          src="/scripts/vendor/require.min.js"
-          data-main="/{{ localeDir }}/homepage/scripts/main.js">
+          src="/{{ localeDir }}/homepage/scripts/main.js">
       </script>
 
       {% block top %}{% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const webpack = require("webpack");
+// const ExtractTextPlugin = require("extract-text-webpack-plugin");
+const path = require("path");
+
+const env = require("./server/lib/environment");
+
+const IS_DEVELOPMENT = env.get("NODE_ENV") === "development";
+const plugins = [];
+
+if(!IS_DEVELOPMENT) {
+  plugins.push(
+    new webpack.optimize.UglifyJsPlugin()
+  );
+}
+
+function absolutePublicPath(filePath) {
+  return path.resolve(__dirname, "public", filePath);
+}
+
+const HOMEPAGE_CONFIG = {
+  entry: [
+    "homepage/scripts/main.js"
+  ]
+  .map(absolutePublicPath),
+
+  output: {
+    path: path.resolve(__dirname, "dist/homepage"),
+    pathinfo: IS_DEVELOPMENT,
+    filename: "scripts/main.js"
+  }
+};
+
+module.exports = [
+  HOMEPAGE_CONFIG
+].map(config => Object.assign(config, {
+  plugins
+}));


### PR DESCRIPTION
This patch is the first step in adding webpack to Thimble and switching away from requirejs and grunt.

### Changes in this patch
1. **Gruntfile.js** - Removes all the homepage scripts from the requirejs build step
2. **package.json** - Adds webpack and the npm scripts to run them
3. **public/homepage/scripts/(gallery | features | getinvolved).js** - None of the code has changed here. The only change made is to convert the require calls to CommonJS. It appears as a huge change due to indentation changes.
4. **public/homepage/scripts/main.js** - Requirejs config removed. Everything converted to commonjs. Removed passing around the modules via functions since they are required in.
5. **public/lib/(keyhandler | popupmenu | underlay).js** - These are identical copies to the files in `public/editor/scripts/editor/js/fc/` corresponding to `bramble-keyhandler.js`, `bramble-popupmenu.js` and `bramble-underlay.js`. I had to create a copy of these files and put them into `lib` because the code is shared with the scripts in `public/editor/scripts` which uses requirejs. Thus, to convert them into commonjs, I had to make copies of them. This is work that needs to happen anyway since it is shared code between the editor and the homepage.
6. **scripts/localize-client-webpack.js** - A temporary file that will exist till the webpack transition is completed. It calls functions from the regular `localize-client.js` file, however, we ignore the homepage scripts in `localize-client` since the source for localization is from `dist` (which is where the webpacked content will live) whereas `localize-client` enforces a source of `public`. Once we switch completely to webpack, this will disappear and the `localize-client` script will effectively turn into a webpack loader.

### Testing
1. Run `npm install` followed by `npm start`. Open up `localhost:3500` and try to navigate the website. On the homepage, check the network tab and make sure that only a single main.js file is loaded.
2. Change the entry for `NODE_ENV` in `.env` to `production`. Follow 1. above but make sure that the main.js file is minified.

### Notes
1. Watching the client for the homepage scripts no longer works. This is temporary and will be fixed once webpack is fully implemented as we will switch to webpack watch.
2. We will need to be careful about making changes to `public/editor/scripts/editor/js/fc/(bramble-keyhandler | bramble-popupmenu | bramble-underlay).js` to make sure that the same changes are made in their corresponding `public/lib` files.