### PR TITLE
Remove unneeded strings for unzip/untar

### DIFF
--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -144,10 +144,6 @@ DND_ERROR_UNZIP=unable to unzip file
 DND_ERROR_UNTAR=unable to untar file
 DND_SUCCESS_UNZIP_TITLE=Unzip Completed Successfully
 DND_SUCCESS_UNTAR_TITLE=Untar Completed Successfully
-# {0} will be replaced by a zip filename
-DND_SUCCESS_UNZIP=Successfully unzipped <b>{0}</b>.
-# {0} will be replaced by a tar filename
-DND_SUCCESS_UNTAR=Successfully untarred <b>{0}</b>.
 DND_FILE_REPLACE=A file named <span class='dialog-filename'>{0}</span> already exists. Do you want to use the new file or keep the existing one?
 
 # Image Viewer


### PR DESCRIPTION
For https://github.com/mozilla/thimble.mozilla.org/issues/2331 I'm removing these strings, since we don't know the name of the file when we import and unzip.