### PR TITLE
Webpack projects list

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,11 +21,9 @@ module.exports = function( grunt ) {
           keepBuildDir: true,
           modules: [{
             name: "editor/scripts/main"
-          }, {
-            name: "projects-list/scripts/main"
           }],
           findNestedDependencies: true,
-          fileExclusionRegExp: /^homepage/,
+          fileExclusionRegExp: /^homepage|^projects-list/,
           optimizeCss: "none",
           removeCombined: true,
           paths: {

--- a/public/editor/scripts/editor/js/fc/bramble-menus.js
+++ b/public/editor/scripts/editor/js/fc/bramble-menus.js
@@ -4,6 +4,7 @@ define(function(require) {
   var PopupMenu = require("fc/bramble-popupmenu");
   var analytics = require("analytics");
 
+  // TODO: Webpack: Use shared/userbar.js functions instead.
   function setupUserMenu() {
     PopupMenu.create("#navbar-logged-in .dropdown-toggle", "#navbar-logged-in .dropdown-content");
   }
@@ -191,7 +192,7 @@ define(function(require) {
 
       return false;
     });
-    
+
     //set the Autocomplete toggle to reflect whether auto-complete is enabled or disabled
     if(bramble.getAutocomplete()) {
         $("#autocomplete-toggle").addClass("switch-enabled");

--- a/public/homepage/scripts/main.js
+++ b/public/homepage/scripts/main.js
@@ -8,7 +8,7 @@ var features = require("./features");
 var gallery = require("./gallery");
 var getinvolved = require("./getinvolved");
 var analytics = require("../../shared/scripts/analytics");
-var PopupMenu = require("../../shared/scripts/popupmenu");
+var userbar = require("../../shared/scripts/userbar");
 
 function setupNewProjectLinks() {
   var authenticated = $("#navbar-login").hasClass("signed-in");
@@ -82,8 +82,7 @@ function setupAuthentication() {
 // separate modules, each of which would be initialized here.
 // See: public/editor/scripts/main.js
 $(function init() {
-  PopupMenu.create("#navbar-logged-in .dropdown-toggle", "#navbar-logged-in .dropdown-content");
-  PopupMenu.create("#navbar-locale .dropdown-toggle", "#navbar-locale .dropdown-content");
+  userbar.createDropdownMenus(["#navbar-help"]);
   setupAuthentication();
   setupNewProjectLinks();
   gallery.init();

--- a/public/projects-list/scripts/main.js
+++ b/public/projects-list/scripts/main.js
@@ -1,114 +1,49 @@
-require.config({
-  waitSeconds: 120,
-  paths: {
-    "jquery": "/node_modules/jquery/dist/jquery.min",
-    "analytics": "/{{ locale }}/shared/scripts/analytics",
-    "constants": "/{{ locale }}/shared/scripts/constants",
-    "uuid": "/node_modules/node-uuid/uuid",
-    "cookies": "/node_modules/cookies-js/dist/cookies",
-    "moment": "/node_modules/moment/min/moment-with-locales.min",
-    "fc/bramble-popupmenu": "/{{ locale }}/editor/scripts/editor/js/fc/bramble-popupmenu",
-    "fc/bramble-keyhandler": "/{{ locale }}/editor/scripts/editor/js/fc/bramble-keyhandler",
-    "fc/bramble-underlay": "/{{ locale }}/editor/scripts/editor/js/fc/bramble-underlay"
-  },
-  shim: {
-    "jquery": {
-      exports: "$"
-    }
-  }
-});
+/* globals $: true */
 
-require(["jquery", "constants", "analytics", "moment"], function($, Constants, analytics, moment) {
-  document.querySelector("#project-list").classList.add("loaded");
-  var projects = document.querySelectorAll(".bramble-user-project");
-  var locale = $("html")[0].lang;
-  var isLocalStorageAvailable = !!(window.localStorage);
-  var favorites;
-  var $projectsToDelete = [];
-  if(isLocalStorageAvailable){
-    try {
-      favorites = JSON.parse(localStorage.getItem("project-favorites")) || [];
-    } catch(e) {
-      console.error("failed to get project favorites from localStorage with: ", e);
-    }
-  }
-  moment.locale($("meta[name='moment-lang']").attr("content"));
+var $ = require("jquery");
+var moment = require("moment");
+require("moment/min/locales.min");
 
-  function getElapsedTime(lastEdited) {
-    var timeElapsed = moment(new Date(lastEdited)).fromNow();
+var Constants = require("../../shared/scripts/constants");
+var analytics = require("../../shared/scripts/analytics");
+var userbar = require("../../shared/scripts/userbar");
 
-    return "{{ momentJSLastEdited | safe }}".replace("<% timeElapsed %>", timeElapsed);
-  }
+var LOCALE = "en-US";
+var favorites;
+var $projectsToDelete = [];
+var $favoriteProjectsList = [];
+var isLocalStorageAvailable = !!(window.localStorage);
 
-  function setFavoriteDataForProject(projectId, projectSelector, project){
-    var indexOfProjectInFavorites = favorites.indexOf(projectId);
-    var projectFavoriteButton = projectSelector + " .project-favorite-button";
+function deleteProject($project) {
+  var projectId = $project.attr("data-project-id");
 
-    if(indexOfProjectInFavorites !== -1){
-      favoriteProjectsElementList.push(project);
-      $(projectFavoriteButton).toggleClass("project-favorite-selected");
-    }
+  analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "Delete Project" });
 
-    $(projectSelector + " .project-favorite-button").on("click", function() {
-      var indexOfProjectInFavorites = favorites.indexOf(projectId);
-      var projectFavoriteButton = projectSelector + " .project-favorite-button";
-
-      if(indexOfProjectInFavorites === -1) {
-        favorites.push(projectId);
-      } else {
-        favorites.splice(indexOfProjectInFavorites, 1);
-      }
-
-      localStorage.setItem("project-favorites", JSON.stringify(favorites));
-      $(projectFavoriteButton).toggleClass("project-favorite-selected");
-    });
-  }
-
-  var favoriteProjectsElementList = [];
-
-  Array.prototype.forEach.call(projects, function(project) {
-    var projectSelector = "#" + project.getAttribute("id");
-    var lastEdited = project.getAttribute("data-project-date_updated");
-    var projectId = project.getAttribute("data-project-id");
-
-    if(isLocalStorageAvailable) {
-      setFavoriteDataForProject(projectId, projectSelector, project);
-    }
-
-    $(projectSelector + " .project-information").text(getElapsedTime(lastEdited));
+  var request = $.ajax({
+    headers: {
+      "X-Csrf-Token": $("meta[name='csrf-token']").attr("content")
+    },
+    type: "DELETE",
+    url: "/" + LOCALE + "/projects/" + projectId,
+    timeout: Constants.AJAX_DEFAULT_TIMEOUT_MS
   });
+  request.done(function(){
+    if(request.status !== 204) {
+      console.error("[Thimble error] Failed to delete project ", projectId, " with status: ", request.status);
+    }
 
-  $("#project-list").prepend(favoriteProjectsElementList);
-
-  function deleteProject($project) {
-    var projectId = $project.attr("data-project-id");
-
-    analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "Delete Project" });
-
-    var request = $.ajax({
-      headers: {
-        "X-Csrf-Token": $("meta[name='csrf-token']").attr("content")
-      },
-      type: "DELETE",
-      url: "/" + locale + "/projects/" + projectId,
-      timeout: Constants.AJAX_DEFAULT_TIMEOUT_MS
-    });
-    request.done(function(){
-      if(request.status !== 204) {
-        console.error("[Thimble error] Failed to delete project ", projectId, " with status: ", request.status);
+    $project.slideToggle({
+      done: function() {
+        $project.remove();
       }
-
-      $project.slideToggle({
-        done: function() {
-          $project.remove();
-        }
-      });
     });
-    request.fail(function(jqXHR, status, err){
-      console.error("Failed to delete project with: ", err);
-    });
-  }
+  });
+  request.fail(function(jqXHR, status, err){
+    console.error("Failed to delete project with: ", err);
+  });
+}
 
+function addProjectDeleteListeners() {
   $(".delete-button").click(function() {
     // TODO: we can do better than this, but let's at least make it harder to lose data.
     if(!window.confirm("{{ deleteProjectConfirmationText }}")) {
@@ -152,34 +87,70 @@ require(["jquery", "constants", "analytics", "moment"], function($, Constants, a
 
     return false;
   });
-});
-
-function init($, uuid, cookies, PopupMenu, analytics) {
-  PopupMenu.create("#navbar-logged-in .dropdown-toggle", "#navbar-logged-in .dropdown-content");
-  PopupMenu.create("#navbar-locale .dropdown-toggle", "#navbar-locale .dropdown-content");
-  setupNewProjectLinks($, analytics);
 }
 
-function setupNewProjectLinks($, analytics) {
-  var queryString = window.location.search;
-  var locale = $("html")[0].lang;
+function setFavoriteDataForProject(projectId, projectSelector, project){
+  var indexOfProjectInFavorites = favorites.indexOf(projectId);
+  var projectFavoriteButton = projectSelector + " .project-favorite-button";
 
-  function newProjectClickHandler(e) {
-    e.preventDefault();
-    e.stopPropagation();
-
-    var cacheBust = "cacheBust=" + Date.now();
-    var qs = queryString === "" ? "?" + cacheBust : queryString + "&" + cacheBust;
-
-    $(e.target).text("{{ newProjectInProgressIndicator }}");
-    $(e.target).addClass("disabled");
-
-    analytics.event({ category : analytics.eventCategories.PROJECT_ACTIONS, action : "New Authenticated Project" });
-    window.location.href = "/" + locale + "/projects/new" + qs;
+  if(indexOfProjectInFavorites !== -1){
+    $favoriteProjectsList.push(project);
+    $(projectFavoriteButton).toggleClass("project-favorite-selected");
   }
 
-  $("#new-project-link").one("click", newProjectClickHandler);
-  $("#project-0").one("click", newProjectClickHandler);
+  $(projectSelector + " .project-favorite-button").on("click", function() {
+    var indexOfProjectInFavorites = favorites.indexOf(projectId);
+    var projectFavoriteButton = projectSelector + " .project-favorite-button";
+
+    if(indexOfProjectInFavorites === -1) {
+      favorites.push(projectId);
+    } else {
+      favorites.splice(indexOfProjectInFavorites, 1);
+    }
+
+    localStorage.setItem("project-favorites", JSON.stringify(favorites));
+    $(projectFavoriteButton).toggleClass("project-favorite-selected");
+  });
 }
 
-require(['jquery', 'uuid', 'cookies', 'fc/bramble-popupmenu', 'analytics'], init);
+function getElapsedTime(lastEdited) {
+  var timeElapsed = moment(new Date(lastEdited)).fromNow();
+
+  return "{{ momentJSLastEdited | safe }}".replace("<% timeElapsed %>", timeElapsed);
+}
+
+function setProjectHandlers() {
+  var projects = document.querySelectorAll(".bramble-user-project");
+
+  Array.prototype.forEach.call(projects, function(project) {
+    var projectSelector = "#" + project.getAttribute("id");
+    var lastEdited = project.getAttribute("data-project-date_updated");
+    var projectId = project.getAttribute("data-project-id");
+
+    if(isLocalStorageAvailable) {
+      setFavoriteDataForProject(projectId, projectSelector, project);
+    }
+
+    $(projectSelector + " .project-information").text(getElapsedTime(lastEdited));
+  });
+
+  $("#project-list").prepend($favoriteProjectsList);
+  addProjectDeleteListeners();
+}
+
+$(function init() {
+  LOCALE = $("html")[0].lang;
+  moment.locale($("meta[name='moment-lang']").attr("content"));
+  userbar.createDropdownMenus(["#navbar-help"]);
+  document.querySelector("#project-list").classList.add("loaded");
+
+  if(isLocalStorageAvailable) {
+    try {
+      favorites = JSON.parse(localStorage.getItem("project-favorites")) || [];
+    } catch(e) {
+      console.error("failed to get project favorites from localStorage with: ", e);
+    }
+  }
+
+  setProjectHandlers();
+});

--- a/public/shared/scripts/constants.js
+++ b/public/shared/scripts/constants.js
@@ -1,4 +1,13 @@
-define(function() {
+(function(global, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(factory);
+  }
+  else if (typeof module === "object" && module && typeof module.exports === "object") {
+    module.exports = factory();
+  } else {
+    global.constants = factory();
+  }
+}(this, function() {
   return {
     ANONYMOUS_USER_FOLDER: "/.anonymous/projects",
     PROJECT_META_KEY: "thimble-project-meta",
@@ -17,4 +26,4 @@ define(function() {
     BACKOFF_MAX_DELAY_MS: 20 * 1000,
     CACHE_KEY_PREFIX: "thimble-cache-key-"
   };
-});
+}));

--- a/public/shared/scripts/userbar.js
+++ b/public/shared/scripts/userbar.js
@@ -1,0 +1,21 @@
+var PopupMenu = require("./popupmenu");
+
+function createDropdownMenus(exclude) {
+  exclude = exclude || [];
+
+  if(exclude.indexOf("#navbar-logged-in") === -1) {
+    PopupMenu.create("#navbar-logged-in .dropdown-toggle", "#navbar-logged-in .dropdown-content");
+  }
+
+  if(exclude.indexOf("#navbar-locale") === -1) {
+    PopupMenu.create("#navbar-locale .dropdown-toggle", "#navbar-locale .dropdown-content");
+  }
+
+  if(exclude.indexOf("#navbar-help") === -1) {
+    PopupMenu.create("#navbar-help .dropdown-toggle", "#navbar-help .dropdown-content");
+  }
+}
+
+module.exports = {
+  createDropdownMenus: createDropdownMenus
+};

--- a/scripts/localize-client-webpack.js
+++ b/scripts/localize-client-webpack.js
@@ -4,10 +4,11 @@ const path = require("path");
 
 const localizeClient = require("./localize-client");
 
-localizeClient.runAll((currentPath, stats) => {
-  // Ignore the homepage dir so that we can localize it separately
+localizeClient.runAll(currentPath => {
+  // Ignore the homepage and projects-list dir so that we
+  // can localize it separately
   // See https://github.com/kriskowal/q-io#listtreepath-guardpath-stat
-  if(path.basename(currentPath) === "homepage") {
+  if(/^homepage$|^projects-list$/.test(path.basename(currentPath))) {
     return null;
   }
 
@@ -20,7 +21,7 @@ localizeClient.runAll((currentPath, stats) => {
   return localizeClient.localizeClientFiles(srcPath, (currentPath, stats) => {
     const relPath = path.relative(srcPath, currentPath);
 
-    if(relPath.indexOf("homepage") === 0 || currentPath === srcPath) {
+    if(/^homepage|^projects-list/.test(relPath) || currentPath === srcPath) {
       return true;
     }
 

--- a/views/projects-list/index.html
+++ b/views/projects-list/index.html
@@ -78,9 +78,7 @@
 
       </div>
 
-      <script src="/scripts/vendor/require.min.js"
-              data-main="/{{ localeDir }}/projects-list/scripts/main.js">
-      </script>
+      <script src="/{{ localeDir }}/projects-list/scripts/main.js"></script>
       <div class="project-list-scroll"></div>
     </div>
   </body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,8 +32,22 @@ const HOMEPAGE_CONFIG = {
   }
 };
 
+const PROJECTS_LIST_CONFIG = {
+  entry: [
+    "projects-list/scripts/main.js"
+  ]
+  .map(absolutePublicPath),
+
+  output: {
+    path: path.resolve(__dirname, "dist/projects-list"),
+    pathinfo: IS_DEVELOPMENT,
+    filename: "scripts/main.js"
+  }
+};
+
 module.exports = [
-  HOMEPAGE_CONFIG
+  HOMEPAGE_CONFIG,
+  PROJECTS_LIST_CONFIG
 ].map(config => Object.assign(config, {
   plugins
 }));


### PR DESCRIPTION
Relies on https://github.com/mozilla/thimble.mozilla.org/pull/2398 being reviewed and landed first.

This does basically the same thing as the previous webpack patch - this time for projects-list.

I didn't really make any code changes other than hoisting some of the variables that were global inside the require module to now being global inside the commonjs module.

I also moved the userbar popup creation logic (which is duplicated in all three modules - homepage, editor and projects-list) into its own module in `shared`. I added a note inside the editor module to switch to using that instead (because right now you can't include the commonjs module inside requirejs without some crazy shims) so that I don't forget to do it when I webpack editor.