### PR TITLE
Fix a hardcoded string in MozFest banner

### DIFF
--- a/views/mozfest.html
+++ b/views/mozfest.html
@@ -5,6 +5,6 @@
         <p>{{ gettext("mozfestInvitationDescription") }}</p>
         <a class="button" href="https://mozillafestival.org/proposals">{{ gettext("mozfestInvitationPropose") }}</a>
         <a href="https://mozillafestival.org/">{{ gettext("mozfestInvitationAbout") }}</a>
-        <a href="mailto:thimble@mozillafoundation.org">{{ gettext("Questions? Get in touch") }}</a>
+        <a href="mailto:thimble@mozillafoundation.org">{{ gettext("mozfestInvitationQuestions") }}</a>
     </div>
 </section>


### PR DESCRIPTION
One of our localizers noticed the error, this should fix it