### PR TITLE
Move thimble out of vagrant and use Node 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ public/stylesheets/userbar.css
 dist/
 client/
 mozilla.webmaker.org
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '8'
+- '6'
 sudo: false
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '4'
+- '8'
 sudo: false
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ All three services are bundled together using Git subtrees to be run together us
 ### Prerequisites for Automated Installation
 In order for Thimble to be installed correctly, the following dependencies need to be installed in order:
 
-- Node.js (version 8.1 or later) [[download](https://nodejs.org/en/download/)]
+- Node.js (version 6.11.1 or later) [[download](https://nodejs.org/en/download/)]
 - [Brackets (Bramble)](#installing-brackets-bramble)
 - Virtualbox (version 5.1 or later) [[download](https://www.virtualbox.org/wiki/Downloads)]
 - Vagrant (version 1.9 or later) [[download](https://www.vagrantup.com/downloads.html)]
@@ -107,7 +107,7 @@ You can also setup Thimble and its needed components outside Vagrant and Virtual
 In order for Thimble to be installed correctly, the following dependencies need to be installed:
 
 - Node.js 4.x or above (see note below)
-  - **Note:** The login.webmaker.org dependency needs a node version of 4.x only while all the other dependencies work with a node version of 4.x and above (Thimble requires node 8.x and above). We suggest installing [NVM](https://github.com/creationix/nvm) to allow the use of multiple versions of node.
+  - **Note:** The login.webmaker.org dependency needs a node version of 4.x only while all the other dependencies work with a node version of 4.x and above (Thimble requires node 6.11.1 or above). We suggest installing [NVM](https://github.com/creationix/nvm) to allow the use of multiple versions of node.
 - [Brackets (Bramble)](#installing-brackets-bramble)
 - [Webmaker ID server](#idwebmakerorg)
 - [Webmaker Publishing Server](#publishwebmakerorg)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Thimble interacts with the Publish API (source managed in [publish.webmaker.org]
 
 For authentication and user management, Thimble uses Webmaker OAuth which consists of the Webmaker ID System (source managed in [id.webmaker.org](htps://github.com/mozilla/id.webmaker.org)) and the Webmaker Login API (source managed in [login.webmaker.org](https://github.com/mozilla/login.webmaker.org)).
 
-All three services along with Thimble are bundled together using Git subtrees to be run together using Vagrant, or, they may be run separately with Thimble [manually](#manual-installation).
+All three services are bundled together using Git subtrees to be run together using Vagrant, or, they may be run separately with Thimble [manually](#manual-installation).
 
 **Note:** The Git subtree bundle mentioned above for use with the automated installation can be found in the `/services` folder. It contains a subtree for each of the three services. These subtrees are not automatically kept in sync with their corresponding service's parent repositories. If you need to update one of the subtrees to match the history of its parent repository, follow these instructions:
   - Create a separate branch and checkout to it.
@@ -55,11 +55,11 @@ All three services along with Thimble are bundled together using Git subtrees to
 ### Prerequisites for Automated Installation
 In order for Thimble to be installed correctly, the following dependencies need to be installed in order:
 
-- Node.js (version 4.6 or later) [[download](https://nodejs.org/en/download/)]
+- Node.js (version 8.1 or later) [[download](https://nodejs.org/en/download/)]
 - [Brackets (Bramble)](#installing-brackets-bramble)
 - Virtualbox (version 5.1 or later) [[download](https://www.virtualbox.org/wiki/Downloads)]
 - Vagrant (version 1.9 or later) [[download](https://www.vagrantup.com/downloads.html)]
-  - __Note:__ On Windows machines, you may need to restart your computer after installing Vagrant for it to be fully usable.  
+  - __Note:__ On Windows machines, you may need to restart your computer after installing Vagrant for it to be fully usable.
   Avoid installation in directories containing *spaces*.  Vagrant is written in Ruby which has issues with directory names containing spaces, so be sure that your VAGRANT_HOME environment variable does not contain any spaces (i.e. a user home folder w/ spaces).  You can set VAGRANT_HOME via Control Panel > Advanced system settings > Environment variables > System Variables or set it from command prompt with [setx]%28https://technet.microsoft.com/en-us/library/cc755104(v=ws.11).aspx%29 command `setx VAGRANT_HOME c:\.vagrant.d -m`.
   For further safety, you can also check to make sure your VM snapshots are stored in a folder without spaces.  To do this, open the Virtualbox GUI, click Preferences > General > Default Machine Folder, and set your path here.
 
@@ -73,39 +73,30 @@ In order for Thimble to be installed correctly, the following dependencies need 
 ### Installing Thimble and Services with Vagrant
 The first step is to fork and clone Thimble and navigate to the cloned directory in a terminal shell.
 
-For the first time, to start all dependent services and Thimble, simply run:
+For the first time, you need to install Thimble's dependencies and start all dependent services. To do this, simply run the following commands in succession:
 
-```
+```sh
+npm run env
+npm install
 vagrant up
 ```
 This process can take a while depending on your internet connection speed as it needs to download all dependencies.
 The Vagrant VM is set to use 1 virtual CPU and 1.5G of RAM. If you find you need to adjust these resource levels, you
 can do so in the `/Vagrantfile`.
 
-When Vagrant finishes provisioning the VM, you will see a log that says `Starting Thimble server on http://localhost:3500/ (this may take a minute...)`.
-At this point you can access Thimble on [http://localhost:3500](http://localhost:3500). NOTE: if it does not work right away, give the server
-another minute to finish starting.
-
-If you want to manually force the Vagrant Thimble server to restart, use `npm run restart-server`.
-
-To suspend the VM use `vagrant suspend` (like putting it to sleep). You can also use `vagrant halt` to do a full shutdown.
-
-To restart the VM and Thimble again, re-run `vagrant up`.
-
-To see logs for the services running in Vagrant, use `npm run logs`.
-
-### Dealing with missing locale strings
-
-Sometimes the locale strings for Thimble change, which requires relocalizing inside of the Vagrant container. If you content that looks like a locale string key, rather than the content it should be, you can try running the following commands to resynchronise the locale string content:
-
+When Vagrant finishes provisioning the VM, all the services that Thimble relies on will be running. Now, you can start the Thimble server by running:
+```sh
+npm start
 ```
-vagrant ssh
-cd /vagrant
-npm run localize
-npm run localize-client
-```
+Once you see a log that says `Express server listening on http://localhost:3500 (this may take a minute...)`, you can access Thimble on [http://localhost:3500](http://localhost:3500).
 
-This will redownload all locale strings and rebuild the client to make use of them.
+You can terminate the Thimble server by hitting Ctrl-C.
+
+To suspend the VM and temporarily stop the services Thimble relies on, use `vagrant suspend` (like putting it to sleep). You can also use `vagrant halt` to do a full shutdown of the services.
+
+To restart the VM and Thimble's services again, re-run `vagrant up`.
+
+To see logs for the services running in Vagrant, use `npm run services:logs`.
 
 ## Manual Installation
 You can also setup Thimble and its needed components outside Vagrant and Virtualbox. This might be needed if you want to:
@@ -116,7 +107,7 @@ You can also setup Thimble and its needed components outside Vagrant and Virtual
 In order for Thimble to be installed correctly, the following dependencies need to be installed:
 
 - Node.js 4.x or above (see note below)
-  - **Note:** The login.webmaker.org dependency needs a node version of 4.x only while all the other dependencies work with a node version of 4.x and above. We suggest installing [NVM](https://github.com/creationix/nvm) to allow the use of multiple versions of node.
+  - **Note:** The login.webmaker.org dependency needs a node version of 4.x only while all the other dependencies work with a node version of 4.x and above (Thimble requires node 8.x and above). We suggest installing [NVM](https://github.com/creationix/nvm) to allow the use of multiple versions of node.
 - [Brackets (Bramble)](#installing-brackets-bramble)
 - [Webmaker ID server](#idwebmakerorg)
 - [Webmaker Publishing Server](#publishwebmakerorg)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,6 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
-  config.vm.network :forwarded_port, host: 3500, guest: 3500 # Thimble
   config.vm.network :forwarded_port, host: 2015, guest: 2015 # publish.webmaker.org
   config.vm.network :forwarded_port, host: 8001, guest: 8001 # Published projects
   config.vm.network :forwarded_port, host: 1234, guest: 1234 # id.webmaker.org
@@ -21,5 +20,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "scripts/setup-services.sh"
 
   # Always provision Thimble and necessary node apps
-  config.vm.provision :shell, path: "scripts/start-services.sh", :run => "always", privileged: false
+  config.vm.provision "shell",
+    run: "always",
+    privileged: false,
+    inline: "pm2 startOrRestart /vagrant/ecosystem.json"
 end

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -36,39 +36,6 @@
                 "ID_SERVER_CONNECTION_STRING": "http://localhost:1234",
                 "FILE_SIZE_LIMIT": 5242880
             }
-        },
-        {
-            "name": "localize-client",
-            "script": "scripts/watch-client.js",
-            "merge_logs": true,
-            "cwd": "/vagrant",
-            "env": {
-                "NODE_ENV": "development"
-            }
-        },
-        {
-            "name": "thimble",
-            "script": "app.js",
-            "watch": true,
-            "ignore_watch": [
-                "/vagrant/.git",
-                "/vagrant/node_modules",
-                "/vagrant/services/login.webmaker.org",
-                "/vagrant/services/id.webmaker.org",
-                "/vagrant/services/publish.webmaker.org",
-                "/vagrant/client",
-                "/vagrant/public",
-                "/vagrant/views"
-            ],
-            "watch_options": {
-                "usePolling": true
-            },
-            "merge_logs": true,
-            "cwd": "/vagrant",
-            "env": {
-                "NODE_ENV": "development",
-                "PROJECT_LOAD_STRATEGY": "tarball"
-            }
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "localize:client": "node scripts/localize-client.js",
     "client": "node scripts/watch-client",
     "server": "node app.js",
-    "restart-server": "vagrant ssh -- pm2 restart thimble ; true",
     "services:logs": "vagrant ssh -- pm2 logs --format",
     "prestart": "run-s build:* localize:*",
     "start": "run-p server client",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MPL-2.0",
   "homepage": "https://thimble.mozilla.org",
   "engines": {
-    "node": "^4.8.4"
+    "node": "^8.1.4"
   },
   "dependencies": {
     "async": "0.2.7",
@@ -75,16 +75,20 @@
     "webpack": "^3.2.0",
     "wolfy87-eventemitter": "^5.1.0"
   },
+  "devDependencies": {
+    "shx": "^0.2.2"
+  },
   "scripts": {
     "postinstall": "run-s build:* localize:*",
     "test": "grunt",
+    "env": "shx cp env.dist .env",
     "build:js": "webpack",
     "localize:locales": "node scripts/properties2json.js",
     "localize:client": "node scripts/localize-client.js",
     "client": "node scripts/watch-client",
     "server": "node app.js",
     "restart-server": "vagrant ssh -- pm2 restart thimble ; true",
-    "logs": "vagrant ssh -- pm2 logs --format",
+    "services:logs": "vagrant ssh -- pm2 logs --format",
     "prestart": "run-s build:* localize:*",
     "start": "run-p server client",
     "invalidate": "node scripts/invalidate.js"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MPL-2.0",
   "homepage": "https://thimble.mozilla.org",
   "engines": {
-    "node": "^8.1.4"
+    "node": "^6.11.1"
   },
   "dependencies": {
     "async": "0.2.7",

--- a/scripts/setup-services.sh
+++ b/scripts/setup-services.sh
@@ -32,7 +32,6 @@ npm install -g node-pre-gyp --loglevel=error # For login.webmaker.org sqlite3
 npm install -g autoless@0.1.7 webpack@1.7.3 --loglevel=error # For id.webmaker.org
 npm install -g knex@">=0.8.6 <0.9.0" --loglevel=error # For publish.webmaker.org
 npm install -g pm2 --loglevel=error # For running Thimble, see scripts/start-services.sh
-npm install -g grunt-cli --loglevel=error # For Thimble's npm postinstall script
 # ---
 
 cd /vagrant
@@ -106,10 +105,4 @@ eval "DATABASE_URL=postgres://$DB_USERNAME:$DB_PASSWORD@localhost:5432/publish n
 cd ..
 mkdir -p /tmp/mox/test # Serve published projects from here
 chown -R vagrant:vagrant /tmp/mox/test # Let vagrant write to this dir
-# ---
-
-# --- thimble setup ---
-cd "$ROOT"
-cp env.dist .env
-npm install --no-bin-links --unsafe-perm --loglevel=error
 # ---

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-pm2 startOrRestart /vagrant/ecosystem.json
-echo "Starting Thimble server on http://localhost:3500/ (this may take a minute...)"
-echo "Use 'npm run restart-server' to force a reload of the server"
-echo "Use 'npm run logs' to see server logs for the node apps in the VM"

--- a/server/index.js
+++ b/server/index.js
@@ -22,7 +22,7 @@ let environment = env.get("NODE_ENV");
 let isDevelopment = environment === "development";
 let root = path.dirname(__dirname);
 let client = path.join(root, isDevelopment ? "client" : "dist");
-let cssAssets = path.join(require("os").tmpDir(), "mozilla.webmaker.org");
+let cssAssets = path.join(require("os").tmpdir(), "mozilla.webmaker.org");
 let editor = url.parse(env.get("BRAMBLE_URI"));
 let editorHost = `${editor.protocol}//${editor.host}`;
 let maxCacheAge = { maxAge: "1d" };


### PR DESCRIPTION
This patch updates the node version to 8 and also removes Thimble out of Vagrant to make dev easier (yay no more breakable watch scripts).

You'll need to run this with Vagrant as per the Readme instructions. Would be good to test out on Windows as well.