### PR TITLE
Makes publish link open in new tab. Fixes #2453

### DIFF
--- a/public/editor/scripts/editor/js/fc/publisher.js
+++ b/public/editor/scripts/editor/js/fc/publisher.js
@@ -287,7 +287,7 @@ define(function(require) {
 
     // Expose the published state with the updated link
     published.link
-      .attr({"href": publishUrl, "target": "_blank"})
+      .attr({"href": publishUrl})
       .text(publishUrl);
     published.changed.addClass("hide");
 

--- a/public/editor/scripts/editor/js/fc/publisher.js
+++ b/public/editor/scripts/editor/js/fc/publisher.js
@@ -287,7 +287,7 @@ define(function(require) {
 
     // Expose the published state with the updated link
     published.link
-      .attr({"href": publishUrl})
+      .attr("href", publishUrl)
       .text(publishUrl);
     published.changed.addClass("hide");
 

--- a/public/editor/scripts/editor/js/fc/publisher.js
+++ b/public/editor/scripts/editor/js/fc/publisher.js
@@ -287,7 +287,7 @@ define(function(require) {
 
     // Expose the published state with the updated link
     published.link
-      .attr("href", publishUrl)
+      .attr({"href": publishUrl, "target": "_blank"})
       .text(publishUrl);
     published.changed.addClass("hide");
 

--- a/views/editor/publish.html
+++ b/views/editor/publish.html
@@ -18,7 +18,7 @@
     <div id="publish-live" class="hide">
       <p>{{ gettext("publishShareLink") }}</p>
       <div id="publish-link">
-        <a id="link-publish-link" title="{{ gettext("publishShareLinkTitle") }}" href="test"></a>
+        <a id="link-publish-link" title="{{ gettext("publishShareLinkTitle") }}" target="_blank" href="test"></a>
       </div>
 
       <div id="publish-button-unpublish">


### PR DESCRIPTION
Fixes issue #2453 [here](https://github.com/mozilla/thimble.mozilla.org/issues/2453).  It makes clicking on the publish link open in a new tab.