### PR TITLE
Merge Default Project Font @include Statements into One

### DIFF
--- a/default/empty-project/style.css
+++ b/default/empty-project/style.css
@@ -1,6 +1,5 @@
 /* Fonts from Google Fonts - more at https://fonts.google.com */
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,700');
-@import url('https://fonts.googleapis.com/css?family=Merriweather:400,700');
+@import url('https://fonts.googleapis.com/css?family=Open+Sans|Merriweather:400,700');
 
 body {
   background-color: white;


### PR DESCRIPTION
I've merged the two, separate `@include` statements in the default project into a single line. I believe this will make the default CSS a little bit smaller and less intimidating for anyone new to CSS, since there's one fewer lines of code for a newbie to try and read and understand. @ryanwarsaw reports that he believes the syntax of the multi-font syntax in a google fonts URL will be too confusing, but I doubt that most people new to development will bother trying to interpret the include URL(s) at all.

Of course, from an optimization standpoint, it'll also ever-so-slightly cut down the number of HTTP requests needed to load the fonts and reduce file size - but this is probably a bit less important to the targeted user base.