### PR TITLE
Fixed styling of the Sign Out error page.

### DIFF
--- a/public/resources/stylesheets/error.less
+++ b/public/resources/stylesheets/error.less
@@ -123,6 +123,7 @@
       border-radius: 2px;
       cursor: pointer;
       text-decoration: none;
+      display: inline-block;
     }
 
     .action-button:hover {

--- a/views/sign-out.html
+++ b/views/sign-out.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/homepage/stylesheets/style.css">
     <link rel="stylesheet" href="/resources/stylesheets/error.css">
   </head>
-  <body class="homepage">
+  <body class="error-page">
 
     <nav class="navbar-thimble container-flex">
       <div id="navbar-left" class="container-flex">
@@ -27,7 +27,9 @@
         <div class="reload-message">
           <h1>{{ gettext("pleaseSignOut") }}</h1>
           <p>{{ gettext("pleaseSignOutMessage") }}</p>
-          <a href="{{ logoutURL }}" class="action-button" target="_self">{{ gettext("signOutButtonLabel") }}</a>
+          <p class="button-wrapper">
+            <a href="{{ logoutURL }}" class="action-button" target="_self">{{ gettext("signOutButtonLabel") }}</a>
+          </p>
         </div>
 
         <div class="contact-icons">


### PR DESCRIPTION
This adds the correct styling to the Sign Out page. It can be viewed by following the steps to reproduce in #2450 and should appear now like this...

![image](https://user-images.githubusercontent.com/25212/30295335-13973ff0-96f5-11e7-8fa9-12478ed7c074.png)

Fixes #2450