### PR TITLE
 Fixes #2378 : Added locale string for PDF Viewer Title 

### DIFF
--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -202,6 +202,9 @@ BINARY_FILE_DOWNLOAD=Download it
 BINARY_FILE_OPEN=Open it in a new tab
 BINARY_FILE_TRY_EDIT=Try to edit it
 
+#PDF Viewer
+PDF_FILE_TITLE=PDF File
+
 ################
 ## EXTENSIONS ##
 ################


### PR DESCRIPTION
@flukeout 
Added locale string to "locales/en-US/editor.properties" for PDF Viewer title corresponding to changes done in brackets.