### PR TITLE
Fix missing styles in remix bar w.r.t. webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "request": "2.80.0",
     "serve-favicon": "^2.4.1",
     "shelljs": "^0.7.8",
+    "svg-url-loader": "^2.1.1",
     "tar-stream": "^1.5.2",
     "throng": "^4.0.0",
     "uuid": "2.0.3",

--- a/public/resources/remix/index.js
+++ b/public/resources/remix/index.js
@@ -125,7 +125,7 @@
 
     stylesheet = document.createElement("link");
     stylesheet.rel = "stylesheet";
-    stylesheet.href = metadata.host + "/resources/remix/style.css";
+    stylesheet.href = metadata.host + "/resources/stylesheets/remix.css";
     document.head.appendChild(stylesheet);
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,9 @@ const moduleConfig = {
         loader: "less-loader"
       }]
     })
+  }, {
+    test: /\.svg$/,
+    loader: "svg-url-loader"
   }]
 };
 
@@ -128,7 +131,8 @@ const RESOURCES_CSS_CONFIG = {
   entry: {
     "error": absolutePublicPath("resources/stylesheets/error.less"),
     "normalize": absolutePublicPath("resources/stylesheets/normalize.less"),
-    "userbar": absolutePublicPath("resources/stylesheets/userbar.less")
+    "userbar": absolutePublicPath("resources/stylesheets/userbar.less"),
+    "remix": absolutePublicPath("resources/remix/style.less")
   },
 
   output: {


### PR DESCRIPTION
The styles were missing in the remix bar for the published projects. It's because we weren't building the remix less file. This does that.