### PR TITLE
Fix 404 on /refresh route, force top-level frame to reload

### DIFF
--- a/public/resources/scripts/error.js
+++ b/public/resources/scripts/error.js
@@ -2,6 +2,6 @@ var tryAgainButton = document.querySelector(".try-again");
 
 if (tryAgainButton) {
   tryAgainButton.addEventListener("click", function() {
-    window.location.reload(true);
+    window.top.location.reload(true);
   });
 }

--- a/views/refresh.html
+++ b/views/refresh.html
@@ -45,6 +45,6 @@
       </div>
     </section>
 
-    <script src="/scripts/error.js"></script>
+    <script src="/resources/scripts/error.js"></script>
   </body>
 </html>

--- a/views/refresh.html
+++ b/views/refresh.html
@@ -45,6 +45,6 @@
       </div>
     </section>
 
-    <script src="/{{ localeDir }}/error/scripts/main.js"></script>
+    <script src="/scripts/error.js"></script>
   </body>
 </html>


### PR DESCRIPTION
We have a 404 when trying to load the `/refresh` route, which this fixes.  Also, this does the reload on the top-level iframe vs. the current window, which we'll need in Brackets.