### PR TITLE
Set base for refresh and include strings

### DIFF
--- a/server/routes/main/refresh.js
+++ b/server/routes/main/refresh.js
@@ -1,4 +1,6 @@
 module.exports = function(config, req, res) {
   res.removeHeader("X-Frame-Options");
-  res.render("refresh.html");
+  res.render("refresh.html", {
+    appURL: config.appURL
+  });
 };

--- a/views/refresh.html
+++ b/views/refresh.html
@@ -4,9 +4,11 @@
 <html lang="{{ locale }}" dir="{{ localeInfo.direction }}">
   <head>
     <meta charset="utf-8">
+    <base href="{{ appURL }}">
     <title>{{ gettext("errorSomethingWentWrong") }}</title>
     <link rel="stylesheet" href="/homepage/stylesheets/style.css">
     <link rel="stylesheet" href="/resources/stylesheets/error.css">
+    <script src="/locales/{{ localeDir }}/strings.js"></script>
   </head>
   <body class="error-page">
 


### PR DESCRIPTION
Sets the origin to resolve absolute/relative paths in the html.
Includes the strings that are needed in the error.js file.