### PR TITLE
Fix #2499 - Fix fallback for missing strings in l10n script

### DIFF
--- a/scripts/localize/index.js
+++ b/scripts/localize/index.js
@@ -79,12 +79,12 @@ co(function*() {
   yield writeFile(
     "en-US",
     "messages.json",
-    Object.assign(enUSServerProperties, enUSSharedProperties)
+    Object.assign({}, enUSServerProperties, enUSSharedProperties)
   );
   yield writeFile(
     "en-US",
     "strings.js",
-    Object.assign(enUSClientProperties, enUSSharedProperties),
+    Object.assign({}, enUSClientProperties, enUSSharedProperties),
     true
   );
 
@@ -102,6 +102,7 @@ co(function*() {
       locale,
       "messages.json",
       Object.assign(
+        {},
         enUSServerProperties,
         enUSSharedProperties,
         serverProperties,
@@ -112,6 +113,7 @@ co(function*() {
       locale,
       "strings.js",
       Object.assign(
+        {},
         enUSClientProperties,
         enUSSharedProperties,
         clientProperties,


### PR DESCRIPTION
Fixes #2499 - en-GB shows greek strings.

`Object.assign` apparently also assigns to the first parameter along with returning the assigned result (yay javascript :unamused:). This meant we kept reassigning the english strings with strings from other locales. By creating a new object literal every time, we ensure that there is no overwriting of objects that we need.