### PR TITLE
Update publish popup title when project is live - Issue 1918 

### DIFF
--- a/locales/en-US/server-client-shared.properties
+++ b/locales/en-US/server-client-shared.properties
@@ -20,3 +20,5 @@ renameProjectSaveBtn=Save
 publishBtn=Publish
 publishDeleteBtn=Delete Published Version
 publishChangesBtn=Update published version
+publishHeader=Publish your Project
+publishHeaderOnline=Your Project is Online

--- a/locales/en-US/server.properties
+++ b/locales/en-US/server.properties
@@ -212,7 +212,6 @@ snippetJSChangeStyleTitle=Change a CSS property of an element
 snippetJSChangeStyleComment=Select the element with id='alert'
 
 # Publishing
-publishHeader=Publish your Project
 publishShareLink=Here's a link you can share…
 publishChangesPrompt=You've made changes since you last published this project.
 publishProjectDescription=Project Description

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "devDependencies": {
     "eslint": "^4.6.1",
     "eslint-plugin-prettier": "^2.2.0",
-    "is-reachable":"^2.3.3",
+    "is-reachable": "^2.3.3",
     "prettier": "^1.6.1",
     "shx": "^0.2.2",
     "stylelint": "^8.1.1",

--- a/public/editor/scripts/ui/publisher.js
+++ b/public/editor/scripts/ui/publisher.js
@@ -14,6 +14,8 @@ var TEXT_UNPUBLISH = strings.get("publishDeleteBtn");
 var TEXT_UNPUBLISHING = strings.get("publishUnpublishingIndicator");
 var TEXT_UPDATE_PUBLISH = strings.get("publishChangesBtn");
 var TEXT_UNPUBLISH_WARNING = strings.get("publishDeleteWarning");
+var TEXT_PUBLISH_HEADER = strings.get("publishHeader");
+var TEXT_PUBLISH_HEADER_ONLINE = strings.get("publishHeaderOnline");
 
 function unpublishedChangesPrompt() {
   var dialog = this.dialog;
@@ -34,6 +36,7 @@ function Publisher() {
       indexMessage: $("#no-index")
     },
     description: $("#publish-details > textarea.publish-description"),
+    publishHeader: $(".content > h1"),
     published: {
       link: $("#publish-link > a"),
       changed: $("#publish-changes"),
@@ -319,10 +322,12 @@ Publisher.prototype.updateDialog = function(publishUrl, allowUnpublish) {
   // "publish"/"cancel" buttons
   if (allowUnpublish) {
     this.dialog.buttons.parent.addClass("hide");
+    this.dialog.publishHeader.text(TEXT_PUBLISH_HEADER_ONLINE);
     unpublishBtn.off("click", unpublish).on("click", unpublish);
     published.container.removeClass("hide");
   } else {
     published.container.addClass("hide");
+    this.dialog.publishHeader.text(TEXT_PUBLISH_HEADER);
   }
 };
 


### PR DESCRIPTION
Fixes #1918 
The original issue was that the publish popup title would always display **"Publish your Project"** regards if it was live or not.

![](https://cloud.githubusercontent.com/assets/25212/24376855/3cd4c860-12f2-11e7-9ba7-85da8a484922.png)

@flukeout @humphd My solution was to reuse the existing `h1`  in "_views/editor/publish.html_" to assign the value depending on the current state of the project performed on the server side. 
Unpublished title = **"Publish your Project"**  
Published title = **" Your Project is Online"**   

1. created var `TEXT_PUBLISHED_HEADER = strings.get("publishedHeader");` holds the string value from 
_"locales/en-US/server.properties"_

2. added publishHeader to the Publisher() object in "\public\editor\scripts\ui\publisher.js". This gets the `<h1>` id in _"views/editor/publish.html"_
 
3.  `Publisher.prototype.updateDialog` located in  _"views/editor/publish.html"_ already checks the handler of the project status.

4. If the project is published,  the header gets assigned `TEXT_PUBLISHED_HEADER` from step 1

5. If the project is unpublished the header is set to default

![thimble_issue1918_fix_capture](https://user-images.githubusercontent.com/15523758/31315752-aa1b3e98-abec-11e7-8d0e-71b8091fba67.gif)
