### PR TITLE
Fixes issue #2355, adds no index message when updating project without index.html

### DIFF
--- a/locales/en-US/server.properties
+++ b/locales/en-US/server.properties
@@ -217,7 +217,7 @@ publishShareLink=Here's a link you can share…
 publishChangesPrompt=You've made changes since you last published this project.
 publishProjectDescription=Project Description
 publishCancelBtn=Cancel
-noIndexFound=Please add an <strong>"index.html"</strong> file before publishing your project. <a href="{{ learnMoreURL }}">Learn more</a>
+noIndexFound_2=Published projects need an <strong>"index.html"</strong> page, please add it and try again. <a href="{{ learnMoreURL }}">Learn more</a>
 
 ##################
 ## Project List ##

--- a/public/editor/scripts/ui/index.js
+++ b/public/editor/scripts/ui/index.js
@@ -445,6 +445,11 @@ function init(bramble, csrfToken, appUrl) {
     _escKeyHandler = null;
   }
   function showPublishDialog() {
+    $("#updateDialog").hide();
+    $("#no-index-update")
+      .addClass("hide")
+      .removeClass("show");
+
     publishDialogUnderlay = new Underlay("#publish-dialog", hidePublishDialog);
     $("#publish-dialog").show();
 

--- a/public/editor/scripts/ui/publisher.js
+++ b/public/editor/scripts/ui/publisher.js
@@ -145,13 +145,12 @@ Publisher.prototype.publish = function(bramble) {
       publisher.dialogEl.removeClass("cannot-publish");
       publisher.dialogEl.width(publisher.dialogEl.width());
     }
-    if ($('#publish-button-update').is(":visible"))
-    {
-      $('#publish-buttons').show();
-      $('#publish-buttons').css({ 'border-top' : '0px' });      
-      $('#publish-button-publish').hide();
-      $('#publish-button-cancel').hide();                
-    } 
+    if ($("#publish-button-update").is(":visible")) {
+      $("#publish-buttons").show();
+      $("#publish-buttons").css({ "border-top": "0px" });
+      $("#publish-button-publish").hide();
+      $("#publish-button-cancel").hide();
+    }
     publisher.dialogEl.addClass("cannot-publish");
     return;
   }

--- a/public/editor/scripts/ui/publisher.js
+++ b/public/editor/scripts/ui/publisher.js
@@ -145,6 +145,7 @@ Publisher.prototype.publish = function(bramble) {
       publisher.dialogEl.removeClass("cannot-publish");
       publisher.dialogEl.width(publisher.dialogEl.width());
     }
+    $('#publish-buttons').show();
     publisher.dialogEl.addClass("cannot-publish");
     return;
   }

--- a/public/editor/scripts/ui/publisher.js
+++ b/public/editor/scripts/ui/publisher.js
@@ -146,15 +146,17 @@ Publisher.prototype.publish = function(bramble) {
       publisher.dialogEl.width(publisher.dialogEl.width());
     }
     if ($("#publish-button-update").is(":visible")) {
-      $("#publish-buttons").show();
-      $("#publish-buttons").css({ "border-top": "0px" });
-      $("#publish-button-publish").hide();
-      $("#publish-button-cancel").hide();
+      $("#updateDialog").show();
+      $("#no-index-update")
+        .removeClass("hide")
+        .addClass("show");
     }
+
     publisher.dialogEl.addClass("cannot-publish");
     return;
   }
 
+  console.info("After");
   publisher.publishing = true;
 
   function setState(done) {
@@ -230,6 +232,11 @@ Publisher.prototype.unpublish = function() {
   if (publisher.unpublishing) {
     return;
   }
+
+  $("#updateDialog").hide();
+  $("#no-index-update")
+    .removeClass("show")
+    .addClass("hide");
 
   var didConfirm = window.confirm(TEXT_UNPUBLISH_WARNING);
 

--- a/public/editor/scripts/ui/publisher.js
+++ b/public/editor/scripts/ui/publisher.js
@@ -156,7 +156,6 @@ Publisher.prototype.publish = function(bramble) {
     return;
   }
 
-  console.info("After");
   publisher.publishing = true;
 
   function setState(done) {

--- a/public/editor/scripts/ui/publisher.js
+++ b/public/editor/scripts/ui/publisher.js
@@ -145,7 +145,13 @@ Publisher.prototype.publish = function(bramble) {
       publisher.dialogEl.removeClass("cannot-publish");
       publisher.dialogEl.width(publisher.dialogEl.width());
     }
-    $('#publish-buttons').show();
+    if ($('#publish-button-update').is(":visible"))
+    {
+      $('#publish-buttons').show();
+      $('#publish-buttons').css({ 'border-top' : '0px' });      
+      $('#publish-button-publish').hide();
+      $('#publish-button-cancel').hide();                
+    } 
     publisher.dialogEl.addClass("cannot-publish");
     return;
   }

--- a/public/editor/stylesheets/publish.less
+++ b/public/editor/stylesheets/publish.less
@@ -115,12 +115,14 @@
       display: block;
     }
 
-    #publish-buttons {
+    #publish-buttons,
+    #updateDialog {
       background: #ffde8b;
     }
   }
 
-  #publish-buttons {
+  #publish-buttons,
+  #updateDialog {
     border-top: 1px solid #ddd;
     padding: 15px 20px;
     background: rgba(0, 0, 0, 0.05);
@@ -144,6 +146,18 @@
       font-size: 0.9em;
       padding-right: 10px;
       display: none;
+
+      a {
+        color: inherit;
+        font-weight: 600;
+      }
+    }
+
+    #no-index-update {
+      color: #5a4944;
+      position: relative;
+      font-size: 0.9em;
+      padding-right: 10px;
 
       a {
         color: inherit;

--- a/views/editor/publish.html
+++ b/views/editor/publish.html
@@ -40,5 +40,11 @@
     <div id="publish-button-cancel">{{ gettext("publishCancelBtn") }}</div>
     <div id="publish-button-publish">{{ gettext("publishBtn") }}</div>
   </div>
+
+  <div id="updateDialog" class="hide">
+    {% set learnMoreURL = "https://github.com/mozilla/thimble.mozilla.org/wiki/Using-Thimble-FAQ#why-do-i-need-an-indexhtml-file-when-publishing-my-project" %}
+    <div id="no-index-update" class="hide" >{{ gettext("noIndexFound_2") | instantiate | safe }}</div>
+  </div>
 </div>
+
 {% endblock %}

--- a/views/editor/publish.html
+++ b/views/editor/publish.html
@@ -36,7 +36,7 @@
 
   <div id="publish-buttons">
     {% set learnMoreURL = "https://github.com/mozilla/thimble.mozilla.org/wiki/Using-Thimble-FAQ#why-do-i-need-an-indexhtml-file-when-publishing-my-project" %}
-    <div id="no-index">{{ gettext("noIndexFound") | instantiate | safe }}</div>
+    <div id="no-index">{{ gettext("noIndexFound_2") | instantiate | safe }}</div>
     <div id="publish-button-cancel">{{ gettext("publishCancelBtn") }}</div>
     <div id="publish-button-publish">{{ gettext("publishBtn") }}</div>
   </div>

--- a/views/editor/publish.html
+++ b/views/editor/publish.html
@@ -1,4 +1,5 @@
 {% block publishdialog %}
+{% set learnMoreURL = "https://github.com/mozilla/thimble.mozilla.org/wiki/Using-Thimble-FAQ#why-do-i-need-an-indexhtml-file-when-publishing-my-project" %}
 <div id="publish-ssooverride" class="hide"
      data-loginUrl="{{ loginURL }}"
      data-oauth-username="{{ username }}"
@@ -35,14 +36,12 @@
   </div>
 
   <div id="publish-buttons">
-    {% set learnMoreURL = "https://github.com/mozilla/thimble.mozilla.org/wiki/Using-Thimble-FAQ#why-do-i-need-an-indexhtml-file-when-publishing-my-project" %}
     <div id="no-index">{{ gettext("noIndexFound_2") | instantiate | safe }}</div>
     <div id="publish-button-cancel">{{ gettext("publishCancelBtn") }}</div>
     <div id="publish-button-publish">{{ gettext("publishBtn") }}</div>
   </div>
 
   <div id="updateDialog" class="hide">
-    {% set learnMoreURL = "https://github.com/mozilla/thimble.mozilla.org/wiki/Using-Thimble-FAQ#why-do-i-need-an-indexhtml-file-when-publishing-my-project" %}
     <div id="no-index-update" class="hide" >{{ gettext("noIndexFound_2") | instantiate | safe }}</div>
   </div>
 </div>


### PR DESCRIPTION
As a continuation of issue #2355 this allows the no index.html message to show when updating a publish. 

Mainly with jQuery I show `#publish-buttons` then remove the publish and cancel buttons to avoid having two publish buttons (update published version and publish). 

![no index message](https://user-images.githubusercontent.com/27080760/31468484-ea29ad14-aeab-11e7-80d9-a93ee567ed6f.gif)
