### PR TITLE
Fixing #2479: Allow user to change the project description without needing to publish their project.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
   # VM, but users are encouraged to test this and make adjustments below (or file PRs)
   # if you find the VM lagging or unresponsive.
   config.vm.provider "virtualbox" do |v|
-    v.memory = 1536
+    v.memory = 8000
     v.cpus = 1
     v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
   end


### PR DESCRIPTION
Description wasn't saving if the project wasn't published. Now, by clicking cancel while the project is unpublished, the description is saved. Please review this and let me know if there's something that can be fixed.