### PR TITLE
Fixing #2518: Added a min-width to the homepage body to prevent content overflow

### DIFF
--- a/public/homepage/stylesheets/style.less
+++ b/public/homepage/stylesheets/style.less
@@ -2,6 +2,7 @@ body {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 1em;
   font-weight: 400;
+  min-width: 981px;
 }
 
 @import "variables.less";


### PR DESCRIPTION
## Fixing #2518 
### Issue
If you resize the browser window while on the home screen, elements such as the video, and footer will begin to overflow.

![31206109-e11e4f80-a943-11e7-8297-592aa7aa672f](https://user-images.githubusercontent.com/15523758/31804474-9952ed38-b527-11e7-9006-57767555f7c4.gif)

### Fix
I simply added a `max-width: 981px;` to the body tag in public/homepage/stylesheets/style.less

### Result
![31590096-b338cd1e-b1d8-11e7-9534-aabacd637dbe](https://user-images.githubusercontent.com/15523758/31804476-9b399598-b527-11e7-9120-1f9ce66df878.gif)




