### PR TITLE
Fix #2577 - Revert "Update /healthcheck"

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "express": "^4.15.2",
     "extract-text-webpack-plugin": "^3.0.0",
     "form-data": "^0.2.0",
-    "git-rev-sync": "^1.9.1",
     "habitat": "3.1.2",
     "helmet": "^3.5.0",
     "jquery": "^3.2.1",

--- a/server/request.js
+++ b/server/request.js
@@ -7,7 +7,6 @@ let cookieParser = require("cookie-parser");
 let cookieSession = require("cookie-session");
 
 let version = require("../package").version;
-const commit = require("git-rev-sync").long();
 const Logger = require("./logger");
 
 const logFormats = {
@@ -104,7 +103,7 @@ Request.prototype = {
   },
   healthcheck() {
     this.server.get("/healthcheck", (req, res) => {
-      res.json({ http: "okay", version: version, commit: commit });
+      res.json({ http: "okay", version: version });
     });
 
     return this;


### PR DESCRIPTION
This reverts commit 42f69f7654c0d7c8fee644ae52e2f9cae7246be4.

Unfortunately, as I suspected, Heroku doesn't guarantee a git repository and so `git-rev-sync` fails. I'll try to come up with a better solution and file a follow-up issue.