### PR TITLE
changing color saturation of hover background

### DIFF
--- a/public/projects-list/stylesheets/style.less
+++ b/public/projects-list/stylesheets/style.less
@@ -101,7 +101,7 @@ h2 {
     }
 
     &:hover {
-      background: rgba(0, 0, 0, 0.04);
+      background: rgba(0, 0, 0, 0.27);
     }
   }
 


### PR DESCRIPTION
This is my first pull request, my apologies if this is a nuisance! 

I read the contributing guidelines and have been browsing the Thimble homepage. After recently covering a unit on web accessibility with my students (I'm a high school teacher), we thought a slightly darker contrast between the project text boxes and the background of the homepage might be preferable to those visually impaired.