### PR TITLE
Setup environment variables for shutdown

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -65,3 +65,9 @@ ASSERT_TOKEN=false
 # Specify how projects are loaded: load as single tarball ("tarball") or as separate files ("files").
 # The default is "tarball" if not specified.
 PROJECT_LOAD_STRATEGY="files"
+
+# Shutdown new account creation
+SHUTDOWN_NEW_ACCOUNTS=false
+
+# Shutdown new project creation and publishing
+SHUTDOWN_NEW_PROJECTS_AND_PUBLISHING=false

--- a/locales/ach/server.properties
+++ b/locales/ach/server.properties
@@ -24,6 +24,7 @@ pageTitleFeatures=Thimble by Mozilla - Jami
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Dony iyie</a> onyo <a href="#" title="Create an account" id="signup-link" class="navbar-login">Cwe akaunt</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Dony iyie</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Aii, gin mo tye marac!

--- a/locales/bn-BD/server.properties
+++ b/locales/bn-BD/server.properties
@@ -22,6 +22,7 @@ thimbleFooter=Thimble মজিলা লার্নিং নেটওয়া�
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">সাইন ইন করুন</a> অথবা <a href="#" title="Create an account" id="signup-link" class="navbar-login">অ্যাকাউন্ট খুলুন</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">সাইন ইন করুন</a>
 
 # Reload Preview Page
 

--- a/locales/bs/server.properties
+++ b/locales/bs/server.properties
@@ -24,6 +24,7 @@ pageTitleFeatures=Mozilla Thimble - Funkcije
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Prijava</a> ili <a href="#" title="Create an account" id="signup-link" class="navbar-login">Napravi račun</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Prijava</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=O ne, nešto nije uredu!

--- a/locales/cak/server.properties
+++ b/locales/cak/server.properties
@@ -24,6 +24,7 @@ pageTitleFeatures=Thimble ruma Mozilla - Taq Samaj
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Titikirisäx molojri'ïl</a> o <a href="#" title="Create an account" id="signup-link" class="navbar-login">Titz'uk jun rub'i' taqoya'l</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Titikirisäx molojri'ïl</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=¡Uy, k'o ri man ütz rub'anon!

--- a/locales/cs/server.properties
+++ b/locales/cs/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble od Mozilly - Funkce
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Přihlásit se</a> nebo <a href="#" title="Create an account" id="signup-link" class="navbar-login">Vytvořit účet</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Přihlásit se</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Ale ne, něco se pokazilo!

--- a/locales/de/server.properties
+++ b/locales/de/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble von Mozilla – Funktionen
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Melden Sie sich an</a> oder <a href="#" title="Create an account" id="signup-link" class="navbar-login">erstellen Sie ein Benutzerkonto</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Melden Sie sich an</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Oh nein, etwas ist schief gegangen!

--- a/locales/dsb/server.properties
+++ b/locales/dsb/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble wót Mozilla - Funkcije
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Pla Thimble pśizjawiś" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Pśizjawśo se</a> abo <a href="#" title="Konto załožyś" id="signup-link" class="navbar-login">Załožćo konto</a>
+signInPromptHomepage2=<a href="#" title="Pla Thimble pśizjawiś" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Pśizjawśo se</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Ow, něco njejo se raźiło!

--- a/locales/el/server.properties
+++ b/locales/el/server.properties
@@ -31,6 +31,7 @@ pageTitleFeatures=Thimble από τη Mozilla - Χαρακτηριστικά
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Σύνδεση</a> ή <a href="#" title="Create an account" id="signup-link" class="navbar-login">Δημιουργία λογαριασμού</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Σύνδεση</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Ωχ όχι, κάτι πήγε στραβά!

--- a/locales/en-GB/server.properties
+++ b/locales/en-GB/server.properties
@@ -24,6 +24,7 @@ pageTitleFeatures=Thimble by Mozilla - Features
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Sign in</a> or <a href="#" title="Create an account" id="signup-link" class="navbar-login">Create an account</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Sign in</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Oh no, something's wrong!

--- a/locales/en-US/server.properties
+++ b/locales/en-US/server.properties
@@ -36,6 +36,7 @@ startUsingGlitch3=If you have an account on Thimble, please sign in and migrate 
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Sign in</a> or <a href="#" title="Create an account" id="signup-link" class="navbar-login">Create an account</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Sign in</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Oh no, something's wrong!

--- a/locales/es-CL/server.properties
+++ b/locales/es-CL/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble por Mozilla - Funciones
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Conéctate</a> o <a href="#" title="Create an account" id="signup-link" class="navbar-login">Crea una cuenta</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Conéctate</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Chuta, ¡algo se fue a las pailas!

--- a/locales/es/server.properties
+++ b/locales/es/server.properties
@@ -26,6 +26,7 @@ pageTitleFeatures=Thimble de Mozilla - Funciones
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Inicia sesión en Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Inicia sesión</a> o <a href="#" title="Crea una cuenta" id="signup-link" class="navbar-login">crea una cuenta</a>
+signInPromptHomepage2=<a href="#" title="Inicia sesión en Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Inicia sesión</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=¡Oh, no! Algo fue mal

--- a/locales/fr/server.properties
+++ b/locales/fr/server.properties
@@ -31,6 +31,7 @@ pageTitleFeatures=Thimble par Mozilla — Fonctionnalités
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Se connecter à Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Se connecter</a> ou <a href="#" title="Créer un compte" id="signup-link" class="navbar-login">Créer un compte</a>
+signInPromptHomepage2=<a href="#" title="Se connecter à Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Se connecter</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Oups, une erreur s’est produite.

--- a/locales/fy-NL/server.properties
+++ b/locales/fy-NL/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble fan Mozilla - Funksjes
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Oanmelde by Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Oanmelde</a> of <a href="#" title="In account oanmeitsje" id="signup-link" class="navbar-login">In account oanmeitsje</a>
+signInPromptHomepage2=<a href="#" title="Oanmelde by Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Oanmelde</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Oh nee, der is wat mis!

--- a/locales/hsb/server.properties
+++ b/locales/hsb/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble wot Mozilla - Funkcije
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Pola Thimble přizjewić" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Přizjewće so</a> abo <a href="#" title="Konto załožić" id="signup-link" class="navbar-login">Załožće konto</a>
+signInPromptHomepage2=<a href="#" title="Pola Thimble přizjewić" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Přizjewće so</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Ow ně, něšto je so nimokuliło!

--- a/locales/hu/server.properties
+++ b/locales/hu/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble a Mozillától – Funkciók
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Bejelentkezés a Thimble-be" id="login-link" data-loginurl="{{ loginURL }}" class="navbar-login">Jelentkezz be</a> vagy <a href="#" title="Fiók létrehozása" id="signup-link" class="navbar-login">hozz létre egy fiókot</a>
+signInPromptHomepage2=<a href="#" title="Bejelentkezés a Thimble-be" id="login-link" data-loginurl="{{ loginURL }}" class="navbar-login">Jelentkezz be</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Ó jaj, valami elromlott!

--- a/locales/it/server.properties
+++ b/locales/it/server.properties
@@ -31,6 +31,7 @@ pageTitleFeatures=Thimble di Mozilla – Funzioni
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Accedi a Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Accedi</a> oppure <a href="#" title="Crea un account" id="signup-link" class="navbar-login">registrati</a>
+signInPromptHomepage2=<a href="#" title="Accedi a Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Accedi</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Spiacenti, qualcosa non ha funzionato.

--- a/locales/ja/server.properties
+++ b/locales/ja/server.properties
@@ -24,6 +24,7 @@ pageTitleFeatures=Thimble by Mozilla - 機能
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Thimble にログイン" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">ログイン</a> または <a href="#" title="アカウント作成" id="signup-link" class="navbar-login">アカウント作成</a>
+signInPromptHomepage2=<a href="#" title="Thimble にログイン" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">ログイン</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=何か問題が発生しました！

--- a/locales/ka/server.properties
+++ b/locales/ka/server.properties
@@ -31,6 +31,7 @@ pageTitleFeatures=Thimble Mozilla-სგან - შესაძლებლო�
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">შედით</a> ან <a href="#" title="Create an account" id="signup-link" class="navbar-login">შექმენით ანგარიში</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">შედით</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=სამწუხაროდ, რაღაც ხარვეზი წარმოიქმნა!

--- a/locales/kab/server.properties
+++ b/locales/kab/server.properties
@@ -27,6 +27,7 @@ pageTitleFeatures=Thimble sγur Mozilla- Timahaltin
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Kcem ar Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Kcem</a> or <a href="#" title="Rnu amiḍan" id="signup-link" class="navbar-login">Rnu amiḍan</a>
+signInPromptHomepage2=<a href="#" title="Kcem ar Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Kcem</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Ihuh, yella wayen yeḍran!
@@ -267,7 +268,7 @@ themeFeatureTitle=Siɣ tafat neɣ sens-itt
 themeFeatureDesc=Thimble ɣur-s asentel aceɛlal akked usentel ubrik, fren win yernan fell-ak. Tzemreḍ ad tbeddleḍ kra n yiɣewwaṛen am teɣzi n uḍris.
 tutorialFeatureTitle=Ḍfeṛ sakin rnu atuṭuryel usliɣ
 tutorialFeatureDesc=Kran n yisenfaṛen zemren ad d-sumren ituṭuryalen ad ak-d-imudden afus (neɣ ad mudden afus i yinelmadne) akken ad issinen deg ubeddel n yisenfaṛen-agi.
-autocompleteFeatureTitle=Taččart tawurman n tengalt 
+autocompleteFeatureTitle=Taččart tawurman n tengalt
 autocompleteFeatureDesc=Ur ḍeggir ara akud-ik deg uɛraḍ n uceffu n tegrumma n yilugan akked tseddast. Thimble ad ak-d-isumer taččart tawurmant n kra n yiḥricen n tengalt HTML, CSS akked JavaScript.
 inlineCSSFeatureTitle=Beddel srid CSS deg isebtar HTML
 inlineCSSFeatureDesc=Aru iɣunab CSS i yiferdisen-ik war ma teffɣeḍ seg usebter HTML ara tettaruḍ. Sers taḥnaccaḍt ɣef yal aferdis sakin senneḍ ɣef <span class="key"> Cmd/Ctrl</span>+<span class="key">E</span> akken ad tebduḍ tira n yiɣunab CSS.
@@ -338,7 +339,7 @@ peiying16Quote=“Ḥemmleɣ Thimble, daɣen ḥemmleɣ ad fruɣ uguren akked te
 th30Contrib1=Ileqqem isemda n tukkit n wumuɣen
 th30Contrib2=Yeḍmen d akken ifuyla ad d-banen akken iwata deg umaẓrag
 th30Quote=« Axeddim ɣef Thimble d acqirreɣ daɣen d tarrayt meqqren akken ad tkecmeḍ deg umaḍal ilelli. Ayagi yeǧǧa-yi ad kkiɣ daɣen ad xedmeɣ akked imdanen ufrinen, i d-yessefhamen yal tikelt d akken tuccḍiwin-ik d tignatin akken ad tesnerniḍ ayen i d-snulfuyeḍ. Tulsa d ayen ẓẓayen, daɣen ad k-teǧǧ ad terreḍ ayen i d-wwiḍ ar tignatin akken ad tlemdeḍ tiɣawsiwin timaynutin ! »
-omytryniukContrib1=Yenerna agrudem n tmeskant tusliɣt n tugniwin 
+omytryniukContrib1=Yenerna agrudem n tmeskant tusliɣt n tugniwin
 omytryniukContrib2=Yerna ddeqs n usnerni deg ugrudem daɣen iseɣta uguren deg uɣanib n ugrudem akked timahilin
 omytryniukContrib3=Ileqqem timunent n tengalt deg usenfaṛ Thimble
 omytryniukQuote=« Ɣur-i nekk, attekki di Thimble ur yettaǧǧa ara kan ad tissineḍ tarmit ifazen s usihel, ayagi yettmuddu-d ladɣa aḥulfu n wawaḍ ticki nttekka deg ufaris i seqdacen yimdanen deg umaḍal meṛṛa. Ticki walaɣ imelyan deg umaḍal ttfaṛasen tagnit si tengalt i yuriɣ, d ayen i yid-yettmuddun afud di Thimble. Ayen-nniḍend tarbaɛt n yimdukal tuḥdiwt deg usenfaṛ i yiǧǧan attekki-iw ar Thimble d tarmit yessefṛaḥen. »

--- a/locales/ko/server.properties
+++ b/locales/ko/server.properties
@@ -24,6 +24,7 @@ pageTitleFeatures=Mozilla Thimble - 특징
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Thimble에 로그인" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">로그인</a> 또는 <a href="#" title="계정 만들기" id="signup-link" class="navbar-login">계정 만들기</a>
+signInPromptHomepage2=<a href="#" title="Thimble에 로그인" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">로그인</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=앗, 뭔가 잘못 됐습니다!

--- a/locales/ms/server.properties
+++ b/locales/ms/server.properties
@@ -31,6 +31,7 @@ pageTitleFeatures=Thimble oleh Mozilla - Ciri
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Daftar masuk</a> atau <a href="#" title="Create an account" id="signup-link" class="navbar-login">Cipta akaun</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Daftar masuk</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Alamak, ada yang tidak kena!

--- a/locales/nl/server.properties
+++ b/locales/nl/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble van Mozilla - Functies
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Aanmelden bij Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Aanmelden</a> of <a href="#" title="Een account aanmaken" id="signup-link" class="navbar-login">Een account aanmaken</a>
+signInPromptHomepage2=<a href="#" title="Aanmelden bij Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Aanmelden</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=O nee, er is iets mis!

--- a/locales/nn-NO/server.properties
+++ b/locales/nn-NO/server.properties
@@ -24,6 +24,7 @@ pageTitleFeatures=Thimble av Mozilla - funksjonar
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Logg inn</a> eller <a href="#" title="Create an account" id="signup-link" class="navbar-login">opprett ein konto</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Logg inn</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Å nei, noko gjekk gale!

--- a/locales/pt-BR/server.properties
+++ b/locales/pt-BR/server.properties
@@ -24,6 +24,7 @@ pageTitleFeatures=Thimble by Mozilla - Funcionalidades
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Iniciar sessão</a> ou <a href="#" title="Create an account" id="signup-link" class="navbar-login">crie uma conta</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Iniciar sessão</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Ah não, algo está errado!

--- a/locales/pt-PT/server.properties
+++ b/locales/pt-PT/server.properties
@@ -31,6 +31,7 @@ pageTitleFeatures=Thimble da Mozilla - Funcionalidades
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Iniciar sessão</a> ou <a href="#" title="Create an account" id="signup-link" class="navbar-login">Criar uma conta</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Iniciar sessão</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Oh não, algo está errado!

--- a/locales/ru/server.properties
+++ b/locales/ru/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble от Mozilla - Возможности
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Войти в Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Войти</a> или <a href="#" title="Создать аккаунт" id="signup-link" class="navbar-login">создать аккаунт</a>
+signInPromptHomepage2=<a href="#" title="Войти в Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Войти</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=О нет, что-то не так!

--- a/locales/sk/server.properties
+++ b/locales/sk/server.properties
@@ -31,6 +31,7 @@ pageTitleFeatures=Thimble od Mozilly - Funkcie
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Prihláste sa</a> alebo <a href="#" title="Create an account" id="signup-link" class="navbar-login">si založte účet</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Prihláste sa</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Ale nie, niečo sa pokazilo!

--- a/locales/sl/server.properties
+++ b/locales/sl/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Mozilla Thimble - Možnosti
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Prijava</a> ali <a href="#" title="Create an account" id="signup-link" class="navbar-login">Ustvari račun</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Prijava</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=O ne, nekaj je narobe!

--- a/locales/sq/server.properties
+++ b/locales/sq/server.properties
@@ -31,6 +31,7 @@ pageTitleFeatures=Thimble nga Mozilla - Veçori
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Hyni në Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Hyni</a> ose <a href="#" title="Krijoni një llogari" id="signup-link" class="navbar-login">Krijoni një llogari</a>
+signInPromptHomepage2=<a href="#" title="Hyni në Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Hyni</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Mos, diç shkoi ters!

--- a/locales/sv-SE/server.properties
+++ b/locales/sv-SE/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble av Mozilla - funktioner
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Logga in</a> eller <a href="#" title="Create an account" id="signup-link" class="navbar-login">skapa ett konto</a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Logga in</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Å nej, nått gick fel!

--- a/locales/tg/server.properties
+++ b/locales/tg/server.properties
@@ -25,6 +25,7 @@ pageTitleFeatures=Thimble by Mozilla - Хусусиятҳо
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Воридшавӣ</a> ё <a href="#" title="Create an account" id="signup-link" class="navbar-login">Сохтани аккаунт </a>
+signInPromptHomepage2=<a href="#" title="Sign in to Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Воридшавӣ</a>
 
 ############
 ## Editor ##

--- a/locales/tr/server.properties
+++ b/locales/tr/server.properties
@@ -28,6 +28,7 @@ pageTitleFeatures=Mozilla’dan Thimble - Özellikler
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Thimble'a giriş yap" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Giriş yap</a> veya <a href="#" title="Create an account" id="signup-link" class="navbar-login">hesap oluştur</a>
+signInPromptHomepage2=<a href="#" title="Thimble'a giriş yap" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Giriş yap</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Bir şeyler ters gitti!

--- a/locales/uk/server.properties
+++ b/locales/uk/server.properties
@@ -25,6 +25,7 @@ pageTitleFeatures=Thimble від Mozilla - Функції
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Увійти в Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Увійти</a> чи <a href="#" title="Створити обліковий запис" id="signup-link" class="navbar-login">створити обліковий запис</a>
+signInPromptHomepage2=<a href="#" title="Увійти в Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Увійти</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=Ой леле, щось пішло не так!

--- a/locales/vi/server.properties
+++ b/locales/vi/server.properties
@@ -22,6 +22,7 @@ thimbleFooter=Thimble là một phần của mạng lưới  học tập của M
 
 # Userbar
 signInPromptHomepage=<a href="#" title="Đăng nhập Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Đăng nhập</a> hoặc <a href="#" title="Tạo một tài khoản" id="signup-link" class="navbar-login">Tạo một tài khoản</a>
+signInPromptHomepage2=<a href="#" title="Đăng nhập Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">Đăng nhập</a>
 
 # Reload Preview Page
 

--- a/locales/zh-CN/server.properties
+++ b/locales/zh-CN/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Mozilla Thimble - 功能
 
 # Userbar
 signInPromptHomepage=<a href="#" title="登录 Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">登录</a>或<a href="#" title="创建一个账号" id="signup-link" class="navbar-login">创建一个账号</a>
+signInPromptHomepage2=<a href="#" title="登录 Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">登录</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=哦！好像出错了！

--- a/locales/zh-TW/server.properties
+++ b/locales/zh-TW/server.properties
@@ -32,6 +32,7 @@ pageTitleFeatures=Thimble by Mozilla - 功能
 
 # Userbar
 signInPromptHomepage=<a href="#" title="登入至 Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">登入</a> 或 <a href="#" title="註冊帳號" id="signup-link" class="navbar-login">註冊帳號</a>
+signInPromptHomepage2=<a href="#" title="登入至 Thimble" id="login-link" data-loginUrl="{{ loginURL }}" class="navbar-login">登入</a>
 
 # Reload Preview Page
 errorCantLoadPreviewTitle=喔不，有點東西不對勁！

--- a/public/resources/remix/style.less
+++ b/public/resources/remix/style.less
@@ -21,6 +21,7 @@
 }
 
 .details-bar {
+  display: none !important;
   position: fixed !important;
   top: 0 !important;
   right: 0 !important;

--- a/public/resources/remix/style.less
+++ b/public/resources/remix/style.less
@@ -21,7 +21,6 @@
 }
 
 .details-bar {
-  display: none !important;
   position: fixed !important;
   top: 0 !important;
   right: 0 !important;

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -55,5 +55,7 @@ module.exports = {
     childSrc: [editorDomain, homepageVideoLink],
     scriptSrc: [editorDomain],
     connectSrc: [editorDomain]
-  }
+  },
+  shutdownNewAccounts: env.get("SHUTDOWN_NEW_ACCOUNTS", false),
+  shutdownNewProjectsAndPublishing: env.get("SHUTDOWN_NEW_PROJECTS_AND_PUBLISHING", false)
 };

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -57,5 +57,8 @@ module.exports = {
     connectSrc: [editorDomain]
   },
   shutdownNewAccounts: env.get("SHUTDOWN_NEW_ACCOUNTS", false),
-  shutdownNewProjectsAndPublishing: env.get("SHUTDOWN_NEW_PROJECTS_AND_PUBLISHING", false)
+  shutdownNewProjectsAndPublishing: env.get(
+    "SHUTDOWN_NEW_PROJECTS_AND_PUBLISHING",
+    false
+  )
 };

--- a/server/routes/main/editor.js
+++ b/server/routes/main/editor.js
@@ -77,7 +77,9 @@ module.exports = function(config, req, res, next) {
     logoutURL: config.logoutURL,
     queryString: qs,
     glitchExportEnabled: req.user && config.glitch.exportEnabled,
-    glitch: req.user && config.glitch
+    glitch: req.user && config.glitch,
+    shutdownNewAccounts: config.shutdownNewAccounts,
+    shutdownNewProjectsAndPublishing: config.shutdownNewProjectsAndPublishing
   };
 
   // We add the localization code to the query params through a URL object

--- a/server/routes/main/features.js
+++ b/server/routes/main/features.js
@@ -23,7 +23,9 @@ module.exports = function(config, req, res) {
     pageName: "features",
     glitchExportEnabled: req.user && config.glitch.exportEnabled,
     migrationDate: migrationDate,
-    moreInfoURL: config.glitch.moreInfoURL
+    moreInfoURL: config.glitch.moreInfoURL,
+    shutdownNewAccounts: config.shutdownNewAccounts,
+    shutdownNewProjectsAndPublishing: config.shutdownNewProjectsAndPublishing
   };
 
   if (req.user) {

--- a/server/routes/main/get-involved.js
+++ b/server/routes/main/get-involved.js
@@ -23,7 +23,9 @@ module.exports = function(config, req, res) {
     pageName: "get-involved",
     glitchExportEnabled: req.user && config.glitch.exportEnabled,
     migrationDate: migrationDate,
-    moreInfoURL: config.glitch.moreInfoURL
+    moreInfoURL: config.glitch.moreInfoURL,
+    shutdownNewAccounts: config.shutdownNewAccounts,
+    shutdownNewProjectsAndPublishing: config.shutdownNewProjectsAndPublishing
   };
 
   if (req.user) {

--- a/server/routes/main/homepage.js
+++ b/server/routes/main/homepage.js
@@ -24,7 +24,9 @@ module.exports = function(config, req, res) {
     moreInfoURL: config.glitch.moreInfoURL,
     URL_PATHNAME: "/" + qs,
     languages: req.app.locals.languages,
-    pageName: "home"
+    pageName: "home",
+    shutdownNewAccounts: config.shutdownNewAccounts,
+    shutdownNewProjectsAndPublishing: config.shutdownNewProjectsAndPublishing
   };
 
   if (req.user) {

--- a/server/routes/main/moving-to-glitch.js
+++ b/server/routes/main/moving-to-glitch.js
@@ -36,7 +36,9 @@ module.exports = function(config, req, res) {
     glitchExportEnabled: req.user && config.glitch.exportEnabled,
     glitch: glitch,
     migrationDate: glitch.migrationDate,
-    moreInfoURL: config.glitch.moreInfoURL
+    moreInfoURL: config.glitch.moreInfoURL,
+    shutdownNewAccounts: config.shutdownNewAccounts,
+    shutdownNewProjectsAndPublishing: config.shutdownNewProjectsAndPublishing
   };
 
   if (req.user) {

--- a/server/routes/projects/read.js
+++ b/server/routes/projects/read.js
@@ -44,12 +44,14 @@ module.exports = function(config, req, res, next) {
       }
 
       if (response.statusCode === 404) {
-        // If there aren't any projects for this user, create one with a redirect
-        res.redirect(307, "/" + locale + "/projects/new" + qs);
-        return;
-      }
-
-      if (response.statusCode !== 200) {
+        if (config.shutdownNewProjectsAndPublishing) {
+          body = "[]";
+        } else {
+          // If there aren't any projects for this user, create one with a redirect
+          res.redirect(307, "/" + locale + "/projects/new" + qs);
+          return;
+        }
+      } else if (response.statusCode !== 200) {
         res.status(response.statusCode);
         next(
           HttpError.format(
@@ -68,6 +70,7 @@ module.exports = function(config, req, res, next) {
       }
 
       var projects;
+
       try {
         projects = JSON.parse(body);
       } catch (e) {
@@ -122,7 +125,9 @@ module.exports = function(config, req, res, next) {
         glitch: req.user && config.glitch,
         migrationDate,
         queryString: qs,
-        logoutURL: config.logoutURL
+        logoutURL: config.logoutURL,
+        shutdownNewAccounts: config.shutdownNewAccounts,
+        shutdownNewProjectsAndPublishing: config.shutdownNewProjectsAndPublishing
       };
 
       res.render("projects-list/index.html", options);

--- a/server/routes/projects/read.js
+++ b/server/routes/projects/read.js
@@ -45,12 +45,17 @@ module.exports = function(config, req, res, next) {
 
       if (response.statusCode === 404) {
         if (config.shutdownNewProjectsAndPublishing) {
-          body = "[]";
+          res.redirect(
+            307,
+            `/${
+              locale
+            }/moving-to-glitch/#can-I-keep-using-thimble-until-I-export`
+          );
         } else {
           // If there aren't any projects for this user, create one with a redirect
           res.redirect(307, "/" + locale + "/projects/new" + qs);
-          return;
         }
+        return;
       } else if (response.statusCode !== 200) {
         res.status(response.statusCode);
         next(

--- a/server/routes/projects/read.js
+++ b/server/routes/projects/read.js
@@ -127,7 +127,8 @@ module.exports = function(config, req, res, next) {
         queryString: qs,
         logoutURL: config.logoutURL,
         shutdownNewAccounts: config.shutdownNewAccounts,
-        shutdownNewProjectsAndPublishing: config.shutdownNewProjectsAndPublishing
+        shutdownNewProjectsAndPublishing:
+          config.shutdownNewProjectsAndPublishing
       };
 
       res.render("projects-list/index.html", options);

--- a/server/routes/projects/remix-bar.js
+++ b/server/routes/projects/remix-bar.js
@@ -23,7 +23,8 @@ module.exports = (config, req, res) => {
     title: params.title,
     author: params.author,
     updated: updated,
-    lang: lang
+    lang: lang,
+    shutdownNewProjectsAndPublishing: config.shutdownNewProjectsAndPublishing
   };
 
   res.render("project-remix-bar.html", options);

--- a/views/editor/userbar.html
+++ b/views/editor/userbar.html
@@ -70,12 +70,14 @@
             </div>
             <div class="dropdown-content">
               <ul>
+                {% if not shutdownNewProjectsAndPublishing %}
                 <li>
                   <a id="new-project-link" href="/{{ locale }}/projects/new">
                     <img src="/img/icon/new-project.svg" />
                     {{ gettext("newProjectLink") }}
                   </a>
                 </li>
+                {% endif %}
                 <li>
                   <a id="delete-project-link">
                     <img src="/img/icon/garbage-can.svg" />
@@ -103,7 +105,7 @@
               </ul>
             </div>
           </div>
-        {% else %}
+        {% elseif not shutdownNewAccounts %}
           {% set publishBtnOpenTag = '<span title="{{ publishBtnTitle }}" id="navbar-publish-button"><img src="/img/icon/publish.svg" class="icon-publish">' | instantiate | safe %}
           {% set publishBtnCloseTag = '</span>' | safe %}
           <div id="navbar-anonymous">
@@ -113,7 +115,7 @@
         </div>
       </div>
 
-    {% if username %}
+    {% if username and not shutdownNewProjectsAndPublishing %}
       <div id="navbar-publish" class="nav-chunk">
         <div title="{{ publishBtnTitle }}" id="navbar-publish-button"><img src="/img/icon/publish.svg" class="icon-publish">{{ gettext("publishBtn") }}
         </div>

--- a/views/gallery.html
+++ b/views/gallery.html
@@ -55,14 +55,18 @@
         <div class='tags'></div>
       </div>
       <div class='buttons'>
+        {% if not shutdownNewProjectsAndPublishing %}
         <a class="remix">{{ gettext("remix") }}</a>
+        {% endif %}
         <a class="teaching-kit">{{ gettext("lessonPlan") }}</a>
       </div>
     </div>
 
+    {% if not shutdownNewProjectsAndPublishing %}
     <p class="contribute-activity">
       {{ gettext("submitProject") | safe }}
     </p>
+    {% endif %}
 
   </div>
 </div>

--- a/views/homepage/index.html
+++ b/views/homepage/index.html
@@ -12,6 +12,7 @@
         <p>
           {{ gettext("thimbleDescription1") | safe }}
         </p>
+        {% if not shutdownNewProjectsAndPublishing %}
         <div class="new-project-button-wrapper">
           <a id="new-project-button" class="feature-button" href="/{{ locale }}/projects/new" title="{{ gettext("newProjectBtnTitle") }}" class="button">
             <div class="pencil-animation">
@@ -25,6 +26,7 @@
             <span id="new-project-button-text">{{ gettext("newProjectBtn") }}</span>
           </a>
         </div>
+        {% endif %}
       </div>
 
       <div class="video">

--- a/views/homepage/userbar.html
+++ b/views/homepage/userbar.html
@@ -53,12 +53,14 @@
 
             <div class="dropdown-content">
               <ul class="dropdown">
+                {% if not shutdownNewProjectsAndPublishing %}
                 <li>
                   <a id="new-project-link" href="/{{ locale }}/projects/new">
                     <img src="/img/icon/new-project.svg" />
                     {{ gettext("newProjectLink") }}
                   </a>
                 </li>
+                {% endif %}
                 <li>
                   <a href="/{{ locale }}/projects/{{ queryString }}" target="_self">
                     <img src="/img/icon/your-projects.svg" />
@@ -75,7 +77,11 @@
             </div>
         {% else %}
           <div id="navbar-anonymous">
+            {% if shutdownNewAccounts %}
+            {{ gettext("signInPromptHomepage2") | instantiate | safe }}
+            {% else %}
             {{ gettext("signInPromptHomepage") | instantiate | safe }}
+            {% endif %}
           </div>
         {% endif %}
         </div>

--- a/views/project-remix-bar.html
+++ b/views/project-remix-bar.html
@@ -1,3 +1,4 @@
+{% if not shutdownNewProjectsAndPublishing %}
 <!-- Project Remix bar -->
 <div lang="{{ lang }}" class="details-bar collapsed cleanslate" style="display: none !important">
   <a class="thimble-logo" title="{{ gettext("thimbleByMozilla") }}" href="https://thimble.mozilla.org">
@@ -20,3 +21,4 @@
   </div>
 </div>
 <!-- End of Remix bar -->
+{% endif %}

--- a/views/projects-list/index.html
+++ b/views/projects-list/index.html
@@ -41,9 +41,11 @@
 
     <div class="project-list-wrapper">
 
+      {% if not shutdownNewProjectsAndPublishing %}
       <a href="/{{ locale }}/projects/new" id="project-0">
         <div title="{{ gettext("prjListNewProjectBtnTitle") }}" class="project-button">{{ gettext("prjListNewProjectBtn") }}</div>
       </a>
+      {% endif %}
 
       <div class="delete-button">
         <img src="/img/icon/garbage-can-white.svg">


### PR DESCRIPTION
The goal of this PR is to remove all elements from the UI that allow:
1. Creating new accounts
2. Publishing, Remixing, or creating new projects
based on checking their respective environment variables.

TO test: set the two new env vars to `true` to make sure they are working, run thimble locally with all dependent services (good luck), and then go through every page and ensure that there aren't any ways to use the above mentioned features using any UI. Also ensure that when you view a published project (publish one before testing with the env vars flipped to true), that the remix button doesn't appear.

Ignore the locale files (checked with Theo to make sure we can do a direct edit), the changes are meant to only remove the "Sign Up" text on the homepage.